### PR TITLE
Add `env` support to config and `-e` CLI flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+- `env` config field (`map[string]string`) for setting arbitrary environment variables via config layers
+- `-e KEY=VALUE` CLI flag for setting environment variables (repeatable, highest precedence)
+
 ## 0.3.1 — 2026-03-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ asylum self-update [--dev]    Update to latest version
 | `-a`, `--agent` | Agent to use: `claude`, `gemini`, `codex` (default: `claude`) |
 | `-p <port>` | Forward a port (repeatable, e.g. `-p 3000 -p 8080:80`) |
 | `-v <volume>` | Mount a volume (repeatable, e.g. `-v ~/data:/data:ro`) |
+| `-e KEY=VALUE` | Set environment variable (repeatable, last wins) |
 | `--java <version>` | Select Java version (`17`, `21`, `25` pre-installed; others installed on demand) |
 | `-n`, `--new` | Start a fresh session (skip auto-resume) |
 | `--rebuild` | Force rebuild the Docker image |
@@ -85,6 +86,10 @@ ports:
 volumes:
   - ~/shared-data:/data:ro
 
+env:
+  MY_API_KEY: "abc123"
+  DEBUG: "true"
+
 versions:
   java: "17"
 
@@ -105,6 +110,7 @@ packages:
 
 - **Scalars** (agent, java version): last value wins
 - **Lists** (ports, volumes): concatenated across layers
+- **Maps** (env, versions): merged per key, last value wins
 - **Package lists** (apt, npm, pip, run): each sub-list concatenated independently
 
 ## How It Works

--- a/cmd/asylum/main.go
+++ b/cmd/asylum/main.go
@@ -81,6 +81,7 @@ func main() {
 		Agent:   flags.Agent,
 		Ports:   flags.Ports,
 		Volumes: flags.Volumes,
+		Env:     flags.Env,
 		Java:    flags.Java,
 	})
 	if err != nil {
@@ -149,6 +150,7 @@ type cliFlags struct {
 	Agent   string
 	Ports   []string
 	Volumes []string
+	Env     map[string]string
 	Java    string
 	New     bool
 	Rebuild bool
@@ -202,6 +204,19 @@ func parseArgs(args []string) (cliFlags, string, []string, error) {
 			var v string
 			if v, err = next(arg); err == nil {
 				flags.Volumes = append(flags.Volumes, v)
+			}
+		case arg == "-e":
+			var val string
+			if val, err = next(arg); err == nil {
+				k, v, ok := strings.Cut(val, "=")
+				if !ok || k == "" {
+					err = fmt.Errorf("invalid env var %q: must be KEY=VALUE", val)
+				} else {
+					if flags.Env == nil {
+						flags.Env = make(map[string]string)
+					}
+					flags.Env[k] = v
+				}
 			}
 		case arg == "--java":
 			flags.Java, err = next(arg)
@@ -382,6 +397,7 @@ Flags:
   -a, --agent <name>   Agent: claude, gemini, codex (default: claude)
   -p <port>            Port forwarding (repeatable)
   -v <volume>          Additional volume mount (repeatable)
+  -e KEY=VALUE         Environment variable (repeatable, last wins)
   --java <version>     Java version in container
   -n, --new            Start new session (skip resume)
   --rebuild            Force rebuild Docker image

--- a/cmd/asylum/main_test.go
+++ b/cmd/asylum/main_test.go
@@ -98,6 +98,38 @@ func TestParseArgs(t *testing.T) {
 			wantFlags: cliFlags{Cleanup: true},
 		},
 
+		// -e env var
+		{
+			name:      "env var single",
+			args:      []string{"-e", "FOO=bar"},
+			wantFlags: cliFlags{Env: map[string]string{"FOO": "bar"}},
+		},
+		{
+			name:      "env var repeatable last wins",
+			args:      []string{"-e", "K=1", "-e", "K=2"},
+			wantFlags: cliFlags{Env: map[string]string{"K": "2"}},
+		},
+		{
+			name:      "env var multiple keys",
+			args:      []string{"-e", "A=1", "-e", "B=2"},
+			wantFlags: cliFlags{Env: map[string]string{"A": "1", "B": "2"}},
+		},
+		{
+			name:      "env var empty value allowed",
+			args:      []string{"-e", "K="},
+			wantFlags: cliFlags{Env: map[string]string{"K": ""}},
+		},
+		{
+			name:    "env var missing equals",
+			args:    []string{"-e", "NOEQUALS"},
+			wantErr: true,
+		},
+		{
+			name:    "env var empty key",
+			args:    []string{"-e", "=value"},
+			wantErr: true,
+		},
+
 		// -- separator
 		{
 			name:      "double dash passes args to agent",
@@ -237,6 +269,11 @@ func TestParseArgs(t *testing.T) {
 		{
 			name:    "trailing --java",
 			args:    []string{"--java"},
+			wantErr: true,
+		},
+		{
+			name:    "trailing -e",
+			args:    []string{"-e"},
 			wantErr: true,
 		},
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	ReleaseChannel string              `yaml:"release-channel"`
 	Ports          []string            `yaml:"ports"`
 	Volumes        []string            `yaml:"volumes"`
+	Env            map[string]string   `yaml:"env"`
 	Versions       map[string]string   `yaml:"versions"`
 	Packages       map[string][]string `yaml:"packages"`
 }
@@ -24,6 +25,7 @@ type CLIFlags struct {
 	Agent   string
 	Ports   []string
 	Volumes []string
+	Env     map[string]string
 	Java    string
 }
 
@@ -95,6 +97,13 @@ func merge(base, overlay Config) Config {
 	result.Ports = slices.Concat(base.Ports, overlay.Ports)
 	result.Volumes = slices.Concat(base.Volumes, overlay.Volumes)
 
+	if overlay.Env != nil {
+		merged := make(map[string]string, len(base.Env)+len(overlay.Env))
+		maps.Copy(merged, base.Env)
+		maps.Copy(merged, overlay.Env)
+		result.Env = merged
+	}
+
 	if overlay.Versions != nil {
 		merged := make(map[string]string, len(base.Versions)+len(overlay.Versions))
 		maps.Copy(merged, base.Versions)
@@ -122,6 +131,12 @@ func applyFlags(cfg Config, flags CLIFlags) Config {
 	}
 	if flags.Java != "" {
 		cfg.Versions = setVersion(cfg.Versions, "java", flags.Java)
+	}
+	if flags.Env != nil {
+		if cfg.Env == nil {
+			cfg.Env = make(map[string]string, len(flags.Env))
+		}
+		maps.Copy(cfg.Env, flags.Env)
 	}
 	cfg.Ports = slices.Concat(cfg.Ports, flags.Ports)
 	cfg.Volumes = slices.Concat(cfg.Volumes, flags.Volumes)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -95,6 +95,36 @@ func TestMerge(t *testing.T) {
 			},
 		},
 		{
+			name: "env map last wins",
+			base: Config{Env: map[string]string{"KEY": "old"}},
+			over: Config{Env: map[string]string{"KEY": "new"}},
+			check: func(t *testing.T, c Config) {
+				if c.Env["KEY"] != "new" {
+					t.Errorf("env KEY = %q, want %q", c.Env["KEY"], "new")
+				}
+			},
+		},
+		{
+			name: "env maps merged",
+			base: Config{Env: map[string]string{"A": "1"}},
+			over: Config{Env: map[string]string{"B": "2"}},
+			check: func(t *testing.T, c Config) {
+				if c.Env["A"] != "1" || c.Env["B"] != "2" {
+					t.Errorf("env = %v, want A=1 B=2", c.Env)
+				}
+			},
+		},
+		{
+			name: "env nil overlay keeps base",
+			base: Config{Env: map[string]string{"A": "1"}},
+			over: Config{},
+			check: func(t *testing.T, c Config) {
+				if c.Env["A"] != "1" {
+					t.Errorf("env A = %q, want %q", c.Env["A"], "1")
+				}
+			},
+		},
+		{
 			name: "nil base maps handled",
 			base: Config{},
 			over: Config{Versions: map[string]string{"java": "21"}, Packages: map[string][]string{"apt": {"curl"}}},
@@ -163,6 +193,19 @@ func TestApplyFlags(t *testing.T) {
 	}
 	if result.Versions["java"] != "17" {
 		t.Errorf("java = %q, want %q", result.Versions["java"], "17")
+	}
+}
+
+func TestApplyFlagsEnv(t *testing.T) {
+	cfg := Config{Env: map[string]string{"A": "1"}}
+	flags := CLIFlags{Env: map[string]string{"A": "2", "B": "3"}}
+	result := applyFlags(cfg, flags)
+
+	if result.Env["A"] != "2" {
+		t.Errorf("env A = %q, want %q", result.Env["A"], "2")
+	}
+	if result.Env["B"] != "3" {
+		t.Errorf("env B = %q, want %q", result.Env["B"], "3")
 	}
 }
 
@@ -267,6 +310,26 @@ ports:
 	}
 	if !found {
 		t.Errorf("ports %v missing 8080", cfg.Ports)
+	}
+}
+
+func TestLoadEnv(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".asylum"), []byte("env:\n  MY_KEY: val1\n  OTHER: base\n"), 0644)
+	os.WriteFile(filepath.Join(dir, ".asylum.local"), []byte("env:\n  MY_KEY: val2\n"), 0644)
+
+	cfg, err := Load(dir, CLIFlags{})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Env["MY_KEY"] != "val2" {
+		t.Errorf("env MY_KEY = %q, want %q", cfg.Env["MY_KEY"], "val2")
+	}
+	if cfg.Env["OTHER"] != "base" {
+		t.Errorf("env OTHER = %q, want %q", cfg.Env["OTHER"], "base")
 	}
 }
 

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -181,6 +181,10 @@ func appendEnvVars(args []string, opts RunOpts) []string {
 		args = append(args, "-e", k+"="+v)
 	}
 
+	for _, k := range slices.Sorted(maps.Keys(opts.Config.Env)) {
+		env(k, opts.Config.Env[k])
+	}
+
 	env("ASYLUM_DOCKER", "1")
 	env("HISTFILE", "/home/claude/.shell_history/zsh_history")
 	env("HOST_PROJECT_DIR", opts.ProjectDir)

--- a/internal/container/container_test.go
+++ b/internal/container/container_test.go
@@ -302,6 +302,45 @@ func TestAppendEnvVars(t *testing.T) {
 		}
 	})
 
+	t.Run("config env vars emitted before hardcoded vars", func(t *testing.T) {
+		cfg := config.Config{Env: map[string]string{"MY_VAR": "hello", "OTHER": "world"}}
+		opts := RunOpts{
+			Config:     cfg,
+			Agent:      stubAgent{envVars: map[string]string{}},
+			ProjectDir: "/work/proj",
+		}
+		got := appendEnvVars([]string{}, opts)
+
+		// Find positions of config env vars and ASYLUM_DOCKER
+		myVarIdx, asylumIdx := -1, -1
+		for i, v := range got {
+			if v == "MY_VAR=hello" {
+				myVarIdx = i
+			}
+			if v == "ASYLUM_DOCKER=1" {
+				asylumIdx = i
+			}
+		}
+		if myVarIdx == -1 {
+			t.Fatalf("MY_VAR=hello not found in %v", got)
+		}
+		if asylumIdx == -1 {
+			t.Fatalf("ASYLUM_DOCKER=1 not found in %v", got)
+		}
+		if myVarIdx > asylumIdx {
+			t.Errorf("config env vars should appear before hardcoded vars, MY_VAR at %d, ASYLUM_DOCKER at %d", myVarIdx, asylumIdx)
+		}
+
+		// Both config env vars present
+		joined := strings.Join(got, " ")
+		if !strings.Contains(joined, "-e MY_VAR=hello") {
+			t.Errorf("expected MY_VAR=hello in %v", got)
+		}
+		if !strings.Contains(joined, "-e OTHER=world") {
+			t.Errorf("expected OTHER=world in %v", got)
+		}
+	})
+
 	t.Run("agent env vars included", func(t *testing.T) {
 		opts := RunOpts{
 			Config:     config.Config{},


### PR DESCRIPTION
## Summary
- Add `env` field (`map[string]string`) to config YAML with same merge semantics as `versions` (last value wins per key)
- Add repeatable `-e KEY=VALUE` CLI flag with highest config precedence
- Config env vars emitted **before** hardcoded/agent env vars in docker args, so internal vars cannot be overridden (Docker last-occurrence-wins)

## Test plan
- [x] `go build ./...` compiles
- [x] `go test ./...` — all tests pass
- [x] `go vet ./...` — no issues
- [ ] Manual: create `.asylum` with `env:` section, run asylum, verify env vars appear in container