### PR TITLE
Auto-install Node.js dependencies on container start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+- Project onboarding framework: scans for setup tasks, prompts once, executes via `docker exec` with proper error handling
+- Node.js dependency auto-install as first onboarding task (disable with `onboarding: { npm: false }`)
+- `--skip-onboarding` CLI flag to skip all onboarding tasks for a single invocation
+- Onboarding state tracking in `~/.asylum/projects/` — skips completed tasks unless lockfile changes
+- `onboarding` config section for per-task control; `features: { onboarding: false }` for global disable
+
 ## 0.4.0 — 2026-03-19
 
 ### Added
@@ -10,7 +17,6 @@
 - Multiple concurrent sessions per project — all modes (agent, shell, run) exec into a running container
 - Container automatically cleaned up when the last session exits (file-based session counter)
 - Integration tests for detached container lifecycle and multi-session behavior
-- Auto-install Node.js dependencies (`npm`, `pnpm`, `yarn`, `bun`) when container starts with empty `node_modules`
 
 ### Changed
 - Container starts detached with idle process; all sessions use `docker exec` instead of `docker run`

--- a/assets/entrypoint.sh
+++ b/assets/entrypoint.sh
@@ -153,6 +153,9 @@ if [ -t 0 ] && [ -t 1 ]; then
     echo ""
 fi
 
+# Export resolved PATH for docker exec consumers (onboarding, etc.)
+echo "$PATH" > /tmp/asylum-path
+
 # If dockerd is running, skip exec so the trap can kill it on exit.
 # Otherwise, exec replaces this shell (saves a process).
 if [ -n "${DOCKERD_PID:-}" ]; then

--- a/cmd/asylum/main.go
+++ b/cmd/asylum/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/inventage-ai/asylum/internal/docker"
 	"github.com/inventage-ai/asylum/internal/image"
 	"github.com/inventage-ai/asylum/internal/log"
+	"github.com/inventage-ai/asylum/internal/onboarding"
 	"github.com/inventage-ai/asylum/internal/selfupdate"
 	"github.com/inventage-ai/asylum/internal/ssh"
 )
@@ -111,6 +112,7 @@ func main() {
 
 	cname := container.ContainerName(projectDir)
 	newSession := flags.New
+	freshContainer := false
 
 	// If no container running, build images and start one detached
 	if !docker.IsRunning(cname) {
@@ -156,6 +158,14 @@ func main() {
 			docker.RemoveContainer(cname)
 			die("container failed to start")
 		}
+		freshContainer = true
+
+		// Fix ownership of shadow node_modules volumes (Docker creates them as root)
+		if !cfg.FeatureOff("shadow-node-modules") {
+			for _, nm := range container.FindNodeModulesDirs(projectDir) {
+				docker.Exec(cname, "root", "chown", "claude", nm)
+			}
+		}
 	}
 
 	// Write session marker for agent mode
@@ -165,6 +175,18 @@ func main() {
 				log.Error("write session marker: %v", err)
 			}
 		}
+	}
+
+	// Run onboarding tasks (agent mode, first container start only)
+	if containerMode == container.ModeAgent && freshContainer && !flags.SkipOnboarding && !cfg.FeatureOff("onboarding") {
+		containerPath, _ := docker.ReadFile(cname, "/tmp/asylum-path")
+		onboarding.Run(onboarding.Opts{
+			ProjectDir:    projectDir,
+			ContainerName: cname,
+			ContainerPath: containerPath,
+			Tasks:         []onboarding.Task{onboarding.NPMTask{}},
+			Onboarding:    cfg.Onboarding,
+		})
 	}
 
 	// Exec session into the running container
@@ -209,8 +231,9 @@ type cliFlags struct {
 	Help    bool
 	Version bool
 	Short   bool
-	Admin   bool
-	Dev     bool
+	Admin          bool
+	Dev            bool
+	SkipOnboarding bool
 	Safe    bool
 }
 
@@ -280,6 +303,9 @@ func parseArgs(args []string) (cliFlags, string, []string, error) {
 			i++
 		case arg == "--cleanup":
 			flags.Cleanup = true
+			i++
+		case arg == "--skip-onboarding":
+			flags.SkipOnboarding = true
 			i++
 		case arg == "--version":
 			flags.Version = true
@@ -505,6 +531,7 @@ Flags:
   --java <version>     Java version in container
   -n, --new            Start new session (skip resume)
   --rebuild            Force rebuild Docker image
+  --skip-onboarding    Skip project onboarding tasks
   --cleanup            Remove Asylum images and cached data
   --version            Show version
   -h, --help           Show this help

--- a/cmd/asylum/main_test.go
+++ b/cmd/asylum/main_test.go
@@ -228,6 +228,13 @@ func TestParseArgs(t *testing.T) {
 			wantErr: true,
 		},
 
+		// --skip-onboarding flag
+		{
+			name:      "skip onboarding",
+			args:      []string{"--skip-onboarding"},
+			wantFlags: cliFlags{SkipOnboarding: true},
+		},
+
 		// strict: unknown flags error
 		{
 			name:    "unknown flag errors",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	Versions       map[string]string   `yaml:"versions"`
 	Packages       map[string][]string `yaml:"packages"`
 	Features       map[string]bool     `yaml:"features"`
+	Onboarding     map[string]bool     `yaml:"onboarding"`
 }
 
 func (c Config) Feature(name string) bool {
@@ -132,6 +133,13 @@ func merge(base, overlay Config) Config {
 		maps.Copy(merged, base.Features)
 		maps.Copy(merged, overlay.Features)
 		result.Features = merged
+	}
+
+	if overlay.Onboarding != nil {
+		merged := make(map[string]bool, len(base.Onboarding)+len(overlay.Onboarding))
+		maps.Copy(merged, base.Onboarding)
+		maps.Copy(merged, overlay.Onboarding)
+		result.Onboarding = merged
 	}
 
 	if overlay.Packages != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -125,6 +125,26 @@ func TestMerge(t *testing.T) {
 			},
 		},
 		{
+			name: "onboarding map last wins",
+			base: Config{Onboarding: map[string]bool{"npm": true}},
+			over: Config{Onboarding: map[string]bool{"npm": false}},
+			check: func(t *testing.T, c Config) {
+				if c.Onboarding["npm"] != false {
+					t.Errorf("onboarding npm = %v, want false", c.Onboarding["npm"])
+				}
+			},
+		},
+		{
+			name: "onboarding nil overlay keeps base",
+			base: Config{Onboarding: map[string]bool{"npm": false}},
+			over: Config{},
+			check: func(t *testing.T, c Config) {
+				if c.Onboarding["npm"] != false {
+					t.Errorf("onboarding npm = %v, want false", c.Onboarding["npm"])
+				}
+			},
+		},
+		{
 			name: "nil base maps handled",
 			base: Config{},
 			over: Config{Versions: map[string]string{"java": "21"}, Packages: map[string][]string{"apt": {"curl"}}},

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -105,7 +105,7 @@ func appendVolumes(args []string, home, cname string, opts RunOpts) ([]string, e
 	// binaries aren't visible inside the container. Named volumes
 	// persist across container restarts so npm install isn't lost.
 	if !opts.Config.FeatureOff("shadow-node-modules") {
-		for _, nm := range findNodeModulesDirs(opts.ProjectDir) {
+		for _, nm := range FindNodeModulesDirs(opts.ProjectDir) {
 			rel, _ := filepath.Rel(opts.ProjectDir, nm)
 			hash := fmt.Sprintf("%x", sha256.Sum256([]byte(rel)))[:11]
 			volName := cname + "-npm-" + hash
@@ -361,12 +361,12 @@ func resolveGitWorktree(projectDir string) (worktreeDir, commonDir string) {
 }
 
 
-// findNodeModulesDirs returns absolute paths to node_modules directories
+// FindNodeModulesDirs returns absolute paths to node_modules directories
 // that should be shadowed. It finds every directory containing a
 // package.json and returns the node_modules path next to it, whether or
 // not node_modules exists yet. This ensures fresh clones get shadow
 // volumes before npm install runs.
-func findNodeModulesDirs(projectDir string) []string {
+func FindNodeModulesDirs(projectDir string) []string {
 	// Directories that never contain relevant package.json files
 	skip := map[string]bool{
 		".git": true, ".venv": true, "__pycache__": true,

--- a/internal/container/container_test.go
+++ b/internal/container/container_test.go
@@ -611,7 +611,7 @@ func TestFindNodeModulesDirs(t *testing.T) {
 		project := t.TempDir()
 		os.WriteFile(filepath.Join(project, "package.json"), []byte("{}"), 0644)
 
-		got := findNodeModulesDirs(project)
+		got := FindNodeModulesDirs(project)
 		want := []string{filepath.Join(project, "node_modules")}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
@@ -623,7 +623,7 @@ func TestFindNodeModulesDirs(t *testing.T) {
 		os.WriteFile(filepath.Join(project, "package.json"), []byte("{}"), 0644)
 		// No node_modules directory created
 
-		got := findNodeModulesDirs(project)
+		got := FindNodeModulesDirs(project)
 		want := []string{filepath.Join(project, "node_modules")}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
@@ -637,7 +637,7 @@ func TestFindNodeModulesDirs(t *testing.T) {
 		os.MkdirAll(pkgDir, 0755)
 		os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte("{}"), 0644)
 
-		got := findNodeModulesDirs(project)
+		got := FindNodeModulesDirs(project)
 		want := []string{
 			filepath.Join(project, "node_modules"),
 			filepath.Join(pkgDir, "node_modules"),
@@ -650,7 +650,7 @@ func TestFindNodeModulesDirs(t *testing.T) {
 	t.Run("no package.json anywhere returns empty", func(t *testing.T) {
 		project := t.TempDir()
 		os.MkdirAll(filepath.Join(project, "src"), 0755)
-		got := findNodeModulesDirs(project)
+		got := FindNodeModulesDirs(project)
 		if len(got) != 0 {
 			t.Errorf("got %v, want empty", got)
 		}
@@ -662,7 +662,7 @@ func TestFindNodeModulesDirs(t *testing.T) {
 		os.MkdirAll(frontend, 0755)
 		os.WriteFile(filepath.Join(frontend, "package.json"), []byte("{}"), 0644)
 
-		got := findNodeModulesDirs(project)
+		got := FindNodeModulesDirs(project)
 		want := []string{filepath.Join(frontend, "node_modules")}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
@@ -677,7 +677,7 @@ func TestFindNodeModulesDirs(t *testing.T) {
 		os.MkdirAll(venvPkg, 0755)
 		os.WriteFile(filepath.Join(venvPkg, "package.json"), []byte("{}"), 0644)
 
-		got := findNodeModulesDirs(project)
+		got := FindNodeModulesDirs(project)
 		// Only root node_modules, not .venv/lib/node_modules
 		want := []string{filepath.Join(project, "node_modules")}
 		if !reflect.DeepEqual(got, want) {
@@ -693,7 +693,7 @@ func TestFindNodeModulesDirs(t *testing.T) {
 		os.MkdirAll(nested, 0755)
 		os.WriteFile(filepath.Join(nested, "package.json"), []byte("{}"), 0644)
 
-		got := findNodeModulesDirs(project)
+		got := FindNodeModulesDirs(project)
 		want := []string{filepath.Join(project, "node_modules")}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -70,6 +70,21 @@ func RunDetached(args []string) error {
 	return cmd.Run()
 }
 
+func Exec(container, user string, command ...string) error {
+	args := []string{"exec", "-u", user, container}
+	args = append(args, command...)
+	return exec.Command("docker", args...).Run()
+}
+
+// ReadFile reads a file from inside a running container.
+func ReadFile(container, path string) (string, error) {
+	out, err := exec.Command("docker", "exec", container, "cat", path).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
 func RemoveContainer(name string) error {
 	cmd := exec.Command("docker", "rm", "-f", name)
 	cmd.Stderr = os.Stderr
@@ -83,15 +98,20 @@ func ShowLogs(name string) {
 	cmd.Run()
 }
 
-// WaitReady polls until the container is running, up to timeoutSec seconds.
+// WaitReady polls until the container is running and the entrypoint has
+// finished (indicated by /tmp/asylum-path existing), up to timeoutSec seconds.
 func WaitReady(name string, timeoutSec int) bool {
 	for i := 0; i < timeoutSec; i++ {
-		if IsRunning(name) {
+		if IsRunning(name) && fileExists(name, "/tmp/asylum-path") {
 			return true
 		}
 		time.Sleep(time.Second)
 	}
 	return false
+}
+
+func fileExists(container, path string) bool {
+	return exec.Command("docker", "exec", container, "test", "-f", path).Run() == nil
 }
 
 func IsRunning(name string) bool {

--- a/internal/onboarding/npm.go
+++ b/internal/onboarding/npm.go
@@ -1,0 +1,49 @@
+package onboarding
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/inventage-ai/asylum/internal/container"
+)
+
+var lockfiles = []struct {
+	file string
+	cmd  []string
+}{
+	{"package-lock.json", []string{"npm", "ci"}},
+	{"pnpm-lock.yaml", []string{"pnpm", "install", "--frozen-lockfile"}},
+	{"yarn.lock", []string{"yarn", "install", "--frozen-lockfile"}},
+	{"bun.lock", []string{"bun", "install", "--frozen-lockfile"}},
+	{"bun.lockb", []string{"bun", "install", "--frozen-lockfile"}},
+}
+
+// NPMTask detects Node.js projects with lockfiles.
+type NPMTask struct{}
+
+func (NPMTask) Name() string { return "npm" }
+
+func (NPMTask) Detect(projectDir string) []Workload {
+	var workloads []Workload
+	for _, nm := range container.FindNodeModulesDirs(projectDir) {
+		dir := filepath.Dir(nm)
+		for _, lf := range lockfiles {
+			lfPath := filepath.Join(dir, lf.file)
+			if _, err := os.Stat(lfPath); err == nil {
+				rel, _ := filepath.Rel(projectDir, dir)
+				if rel == "." {
+					rel = filepath.Base(projectDir)
+				}
+				workloads = append(workloads, Workload{
+					Label:      rel,
+					Command:    lf.cmd,
+					Dir:        dir,
+					HashInputs: []string{lfPath},
+					Phase:      PostContainer,
+				})
+				break
+			}
+		}
+	}
+	return workloads
+}

--- a/internal/onboarding/npm_test.go
+++ b/internal/onboarding/npm_test.go
@@ -1,0 +1,102 @@
+package onboarding
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNPMTaskDetect(t *testing.T) {
+	tests := []struct {
+		name     string
+		lockfile string
+		wantCmd  string
+	}{
+		{"npm", "package-lock.json", "npm"},
+		{"pnpm", "pnpm-lock.yaml", "pnpm"},
+		{"yarn", "yarn.lock", "yarn"},
+		{"bun", "bun.lock", "bun"},
+		{"bun binary", "bun.lockb", "bun"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}"), 0644)
+			os.WriteFile(filepath.Join(dir, tt.lockfile), []byte("lock"), 0644)
+
+			task := NPMTask{}
+			workloads := task.Detect(dir)
+			if len(workloads) != 1 {
+				t.Fatalf("got %d workloads, want 1", len(workloads))
+			}
+			if workloads[0].Command[0] != tt.wantCmd {
+				t.Errorf("command = %q, want %q", workloads[0].Command[0], tt.wantCmd)
+			}
+		})
+	}
+}
+
+func TestNPMTaskDetectNoLockfile(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}"), 0644)
+
+	task := NPMTask{}
+	workloads := task.Detect(dir)
+	if len(workloads) != 0 {
+		t.Errorf("got %d workloads, want 0 (no lockfile)", len(workloads))
+	}
+}
+
+func TestNPMTaskDetectNoPackageJSON(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "package-lock.json"), []byte("lock"), 0644)
+
+	task := NPMTask{}
+	workloads := task.Detect(dir)
+	if len(workloads) != 0 {
+		t.Errorf("got %d workloads, want 0 (no package.json)", len(workloads))
+	}
+}
+
+func TestNPMTaskDetectMonorepo(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}"), 0644)
+	os.WriteFile(filepath.Join(dir, "package-lock.json"), []byte("root-lock"), 0644)
+
+	pkgDir := filepath.Join(dir, "packages", "app")
+	os.MkdirAll(pkgDir, 0755)
+	os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte("{}"), 0644)
+	os.WriteFile(filepath.Join(pkgDir, "package-lock.json"), []byte("app-lock"), 0644)
+
+	task := NPMTask{}
+	workloads := task.Detect(dir)
+	if len(workloads) != 2 {
+		t.Fatalf("got %d workloads, want 2", len(workloads))
+	}
+}
+
+func TestNPMTaskDetectHashInput(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}"), 0644)
+	os.WriteFile(filepath.Join(dir, "pnpm-lock.yaml"), []byte("lock-content"), 0644)
+
+	task := NPMTask{}
+	workloads := task.Detect(dir)
+	if len(workloads) != 1 {
+		t.Fatalf("got %d workloads, want 1", len(workloads))
+	}
+	if len(workloads[0].HashInputs) != 1 {
+		t.Fatalf("expected 1 hash input, got %d", len(workloads[0].HashInputs))
+	}
+	if filepath.Base(workloads[0].HashInputs[0]) != "pnpm-lock.yaml" {
+		t.Errorf("hash input = %q, want pnpm-lock.yaml", workloads[0].HashInputs[0])
+	}
+}
+
+func TestNPMTaskName(t *testing.T) {
+	task := NPMTask{}
+	if task.Name() != "npm" {
+		t.Errorf("name = %q, want %q", task.Name(), "npm")
+	}
+}

--- a/internal/onboarding/onboarding.go
+++ b/internal/onboarding/onboarding.go
@@ -1,0 +1,204 @@
+package onboarding
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/inventage-ai/asylum/internal/log"
+)
+
+// Phase determines when a workload runs relative to the container lifecycle.
+type Phase int
+
+const (
+	PostContainer Phase = iota
+)
+
+// Task detects onboarding workloads for a project.
+type Task interface {
+	Name() string
+	Detect(projectDir string) []Workload
+}
+
+// Workload is a single unit of onboarding work.
+type Workload struct {
+	Label      string   // display name (e.g. "eamportal-view/.../angular")
+	Command    []string // e.g. ["pnpm", "install", "--frozen-lockfile"]
+	Dir        string   // working directory inside container
+	HashInputs []string // paths to files whose hash determines re-run
+	Phase      Phase
+}
+
+// Opts configures an onboarding run.
+type Opts struct {
+	ProjectDir    string
+	ContainerName string
+	ContainerPath string            // resolved PATH from container
+	Tasks         []Task
+	Onboarding    map[string]bool   // per-task config (e.g. {"npm": false})
+}
+
+// State tracks completed onboarding workloads.
+type State map[string]map[string]string // task name → label → hash
+
+func statePath(containerName string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(home, ".asylum", "projects", containerName)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "onboarding.json"), nil
+}
+
+func loadState(containerName string) State {
+	path, err := statePath(containerName)
+	if err != nil {
+		return State{}
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return State{}
+	}
+	var s State
+	if json.Unmarshal(data, &s) != nil {
+		return State{}
+	}
+	return s
+}
+
+func saveState(containerName string, s State) {
+	path, err := statePath(containerName)
+	if err != nil {
+		return
+	}
+	data, _ := json.MarshalIndent(s, "", "  ")
+	os.WriteFile(path, data, 0644)
+}
+
+func hashFile(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	h := sha256.Sum256(data)
+	return fmt.Sprintf("%x", h)
+}
+
+func hashInputs(paths []string) string {
+	h := sha256.New()
+	for _, p := range paths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		h.Write(data)
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+// Run orchestrates onboarding: detect → prompt → execute → save state.
+func Run(opts Opts) {
+	state := loadState(opts.ContainerName)
+
+	var pending []pendingWorkload
+	for _, task := range opts.Tasks {
+		if disabled, ok := opts.Onboarding[task.Name()]; ok && !disabled {
+			continue
+		}
+		taskState := state[task.Name()]
+		if taskState == nil {
+			taskState = map[string]string{}
+		}
+
+		for _, w := range task.Detect(opts.ProjectDir) {
+			hash := hashInputs(w.HashInputs)
+			if taskState[w.Label] == hash {
+				continue
+			}
+			pending = append(pending, pendingWorkload{
+				task:     task.Name(),
+				workload: w,
+				hash:     hash,
+			})
+		}
+	}
+
+	if len(pending) == 0 {
+		return
+	}
+
+	// Consolidated prompt
+	fmt.Println()
+	log.Info("Project onboarding:")
+	for _, p := range pending {
+		fmt.Printf("  - %s (%s)\n", p.workload.Label, strings.Join(p.workload.Command, " "))
+	}
+	fmt.Print("Run setup tasks? [Y/n] ")
+	var answer string
+	fmt.Scanln(&answer)
+	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(answer)), "n") {
+		return
+	}
+
+	// Execute
+	for _, p := range pending {
+		log.Info("running: %s in %s", strings.Join(p.workload.Command, " "), p.workload.Label)
+		if err := execInContainer(opts, p.workload); err != nil {
+			log.Error("%s failed: %v", p.workload.Label, err)
+			continue
+		}
+		// Save state for this workload
+		if state[p.task] == nil {
+			state[p.task] = map[string]string{}
+		}
+		state[p.task][p.workload.Label] = p.hash
+		saveState(opts.ContainerName, state)
+	}
+}
+
+type pendingWorkload struct {
+	task     string
+	workload Workload
+	hash     string
+}
+
+func execInContainer(opts Opts, w Workload) error {
+	args := []string{"exec"}
+	if isTerminal() {
+		args = append(args, "-it")
+	}
+	args = append(args, "-w", w.Dir, opts.ContainerName)
+	if opts.ContainerPath != "" {
+		// Run through bash so PATH is applied before command lookup
+		script := "export PATH=" + shellQuote(opts.ContainerPath) + "; " + strings.Join(w.Command, " ")
+		args = append(args, "bash", "-c", script)
+	} else {
+		args = append(args, w.Command...)
+	}
+
+	cmd := exec.Command("docker", args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func isTerminal() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}

--- a/internal/onboarding/onboarding_test.go
+++ b/internal/onboarding/onboarding_test.go
@@ -1,0 +1,152 @@
+package onboarding
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHashInputs(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "lockfile")
+	os.WriteFile(f, []byte("content-v1"), 0644)
+
+	h1 := hashInputs([]string{f})
+	if h1 == "" {
+		t.Fatal("expected non-empty hash")
+	}
+
+	os.WriteFile(f, []byte("content-v2"), 0644)
+	h2 := hashInputs([]string{f})
+	if h1 == h2 {
+		t.Error("hash should change when file changes")
+	}
+}
+
+func TestHashInputsMissingFile(t *testing.T) {
+	h := hashInputs([]string{"/nonexistent/file"})
+	if h == "" {
+		t.Error("expected non-empty hash even with missing files")
+	}
+}
+
+func TestStateLoadSave(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cname := "asylum-test123"
+
+	// Initially empty
+	s := loadState(cname)
+	if len(s) != 0 {
+		t.Errorf("expected empty state, got %v", s)
+	}
+
+	// Save and reload
+	s["npm"] = map[string]string{"frontend": "abc123"}
+	saveState(cname, s)
+
+	s2 := loadState(cname)
+	if s2["npm"]["frontend"] != "abc123" {
+		t.Errorf("expected abc123, got %q", s2["npm"]["frontend"])
+	}
+}
+
+func TestStatePathCreatesDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	path, err := statePath("asylum-test456")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := filepath.Dir(path)
+	if _, err := os.Stat(dir); err != nil {
+		t.Errorf("expected directory to exist: %v", err)
+	}
+	if filepath.Base(path) != "onboarding.json" {
+		t.Errorf("expected onboarding.json, got %s", filepath.Base(path))
+	}
+}
+
+func TestStatePersistsJSON(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cname := "asylum-jsontest"
+	s := State{"npm": {"app": "hash1", "lib": "hash2"}}
+	saveState(cname, s)
+
+	path, _ := statePath(cname)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var parsed State
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if parsed["npm"]["app"] != "hash1" || parsed["npm"]["lib"] != "hash2" {
+		t.Errorf("unexpected state: %v", parsed)
+	}
+}
+
+type stubTask struct {
+	name      string
+	workloads []Workload
+}
+
+func (s stubTask) Name() string                    { return s.name }
+func (s stubTask) Detect(projectDir string) []Workload { return s.workloads }
+
+func TestPendingDetection(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	projectDir := t.TempDir()
+
+	lockfile := filepath.Join(projectDir, "lock")
+	os.WriteFile(lockfile, []byte("v1"), 0644)
+
+	task := stubTask{
+		name: "test",
+		workloads: []Workload{{
+			Label:      "app",
+			Command:    []string{"install"},
+			Dir:        projectDir,
+			HashInputs: []string{lockfile},
+		}},
+	}
+
+	// First run: should have pending workload
+	state := loadState("asylum-pending-test")
+	taskState := state[task.Name()]
+	if taskState == nil {
+		taskState = map[string]string{}
+	}
+
+	w := task.Detect(projectDir)[0]
+	hash := hashInputs(w.HashInputs)
+	if taskState[w.Label] == hash {
+		t.Error("should be pending on first run")
+	}
+
+	// Simulate completion
+	state["test"] = map[string]string{"app": hash}
+	saveState("asylum-pending-test", state)
+
+	// Second run: should skip
+	state2 := loadState("asylum-pending-test")
+	if state2["test"]["app"] != hash {
+		t.Error("state should persist")
+	}
+
+	// Change lockfile: should be pending again
+	os.WriteFile(lockfile, []byte("v2"), 0644)
+	newHash := hashInputs(w.HashInputs)
+	if state2["test"]["app"] == newHash {
+		t.Error("should be pending after lockfile change")
+	}
+}

--- a/openspec/changes/archive/2026-03-23-auto-install-node-modules/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-23-auto-install-node-modules/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-20

--- a/openspec/changes/archive/2026-03-23-auto-install-node-modules/design.md
+++ b/openspec/changes/archive/2026-03-23-auto-install-node-modules/design.md
@@ -1,0 +1,44 @@
+## Context
+
+Shadow volumes (from the `shadow-node-modules` change) isolate the container from host-built native binaries by mounting empty named volumes over `node_modules`. This means dependencies must be installed inside the container. For agents, this should happen automatically before the agent starts working.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Prompt the user before installing (credentials or build tools may be required).
+- Install runs inside the container where the correct platform binaries are built.
+- Single consolidated prompt for all detected projects (not one per project).
+- Feature can be disabled per-project.
+
+**Non-Goals:**
+- Auto-installing without prompting (too risky — may need credentials or specific build tools).
+- Supporting non-agent modes (shell users can install manually).
+- Detecting non-Node.js dependency managers.
+
+## Decisions
+
+### 1. Prompt on host, install in container
+
+The prompt runs in Go on the host (where the user's terminal is), before the `docker exec` that starts the agent. The install commands are prepended to the agent's exec command via `bash -c`. This avoids entrypoint complexity and ensures the install happens in the interactive session.
+
+### 2. PreRunCmds in ExecOpts
+
+`ExecOpts` gains a `PreRunCmds []string` field. When set, the agent command is wrapped: `bash -c "source ~/.bashrc; cmd1 && cmd2 ; exec agent_binary"`. The PATH setup (`fnm env`) is included so `pnpm`, `npm`, etc. are available.
+
+### 3. Reuse FindNodeModulesDirs for lockfile detection
+
+The same function that finds `node_modules` paths for shadowing is reused to find projects. Each path's parent directory is checked for lockfiles (package-lock.json, pnpm-lock.yaml, yarn.lock, bun.lock/bun.lockb). Projects without lockfiles are skipped.
+
+### 4. Shadow volume ownership fix
+
+Docker creates named volumes as root. After the container starts, asylum runs `docker exec -u root chown claude:claude <path>` for each shadow volume so the container user can write to them.
+
+### 5. Feature flag for opt-out
+
+`features: { auto-install-node-modules: false }` in config disables the prompt entirely. The check uses `FeatureOff()` (default-on pattern).
+
+## Risks / Trade-offs
+
+- **Install failures don't block the agent**: The `bash -c` script uses `&&` between install commands but `;` before `exec agent`, so the agent starts even if installs fail.
+- **PATH setup is duplicated**: The `fnm env` setup in the exec wrapper mirrors the Dockerfile's `.bashrc` setup. If the PATH setup changes in the Dockerfile, it needs updating here too.
+- **Prompt only on first container start**: If the container is already running (second session), the prompt doesn't appear and installs don't run. This is correct — deps persist in the named volume.

--- a/openspec/changes/archive/2026-03-23-auto-install-node-modules/proposal.md
+++ b/openspec/changes/archive/2026-03-23-auto-install-node-modules/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+With shadow volumes, `node_modules` inside the container always starts empty. Agents that work on Node.js projects fail immediately because dependencies aren't installed. Users must manually run `npm ci` or similar before the agent can work.
+
+## What Changes
+
+- In agent mode, before the agent starts, asylum detects Node.js projects with lockfiles and prompts the user to install dependencies.
+- The prompt happens on the host (Go), the install runs inside the container as part of the `docker exec` session.
+- A feature flag `auto-install-node-modules` (default on) allows disabling this behavior.
+- Shadow volumes created by Docker as root are chowned to the container user after container start.
+
+## Capabilities
+
+### New Capabilities
+
+- `auto-install-node-modules`: Detect lockfiles, prompt user, install Node.js dependencies inside the container before the agent starts.
+
+### Modified Capabilities
+
+- `container-assembly`: `ExecArgs` gains `PreRunCmds` support to prepend shell commands before the agent binary. Shadow volume ownership is fixed after container start.
+
+## Impact
+
+- **CLI**: New prompt in agent mode when Node.js lockfiles are detected.
+- **Container exec**: Agent command wrapped in `bash -c` when pre-run commands exist.
+- **Docker**: New `docker.Exec` helper for running commands as a specific user.
+- **Config**: Uses existing `features` map for opt-out.

--- a/openspec/changes/archive/2026-03-23-auto-install-node-modules/specs/auto-install-node-modules/spec.md
+++ b/openspec/changes/archive/2026-03-23-auto-install-node-modules/specs/auto-install-node-modules/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: Detect Node.js projects with lockfiles
+The system SHALL scan for `package.json` files using `FindNodeModulesDirs` and check each project directory for a lockfile to determine the install command.
+
+#### Scenario: npm project
+- **WHEN** a directory contains `package-lock.json`
+- **THEN** the install command is `npm ci`
+
+#### Scenario: pnpm project
+- **WHEN** a directory contains `pnpm-lock.yaml`
+- **THEN** the install command is `pnpm install --frozen-lockfile`
+
+#### Scenario: yarn project
+- **WHEN** a directory contains `yarn.lock`
+- **THEN** the install command is `yarn install --frozen-lockfile`
+
+#### Scenario: bun project
+- **WHEN** a directory contains `bun.lock` or `bun.lockb`
+- **THEN** the install command is `bun install --frozen-lockfile`
+
+#### Scenario: No lockfile
+- **WHEN** a directory has `package.json` but no lockfile
+- **THEN** no install command is generated for that directory
+
+### Requirement: Prompt user before installing
+In agent mode, the system SHALL display all detected projects with their install commands in a single consolidated prompt and ask for confirmation before proceeding.
+
+#### Scenario: User accepts
+- **WHEN** the user presses Enter or types anything other than "n"
+- **THEN** install commands for all listed projects are queued
+
+#### Scenario: User declines
+- **WHEN** the user types "n" or "N"
+- **THEN** no install commands are queued and the agent starts without installs
+
+#### Scenario: No projects detected
+- **WHEN** no lockfiles are found in any Node.js project directory
+- **THEN** no prompt is shown
+
+### Requirement: Install runs inside the container
+The install commands SHALL run inside the container as part of the `docker exec` session, before the agent binary starts.
+
+#### Scenario: Successful install
+- **WHEN** install commands are queued
+- **THEN** they run with PATH set up for fnm/node, then the agent starts via `exec`
+
+#### Scenario: Install failure
+- **WHEN** an install command fails
+- **THEN** the agent still starts (install failures are non-fatal)
+
+### Requirement: Feature can be disabled
+The auto-install feature SHALL be disabled when `features: { auto-install-node-modules: false }` is set in config.
+
+#### Scenario: Feature disabled
+- **WHEN** config has `features: { auto-install-node-modules: false }`
+- **THEN** no lockfile detection or prompting occurs
+
+#### Scenario: Feature enabled by default
+- **WHEN** config does not mention `auto-install-node-modules`
+- **THEN** the auto-install behavior is active in agent mode
+
+### Requirement: Only in agent mode
+The auto-install prompt SHALL only appear in agent mode, not in shell, admin shell, or run modes.
+
+#### Scenario: Shell mode
+- **WHEN** `asylum shell` is run
+- **THEN** no install prompt is shown
+
+#### Scenario: Agent mode
+- **WHEN** `asylum` is run (default agent mode)
+- **THEN** the install prompt is shown if lockfiles are detected

--- a/openspec/changes/archive/2026-03-23-auto-install-node-modules/specs/container-assembly/spec.md
+++ b/openspec/changes/archive/2026-03-23-auto-install-node-modules/specs/container-assembly/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: PreRunCmds in exec args
+When `ExecOpts.PreRunCmds` is non-empty, the agent command SHALL be wrapped in `bash -c` with PATH setup, the pre-run commands joined by `&&`, and the agent command executed via `exec`.
+
+#### Scenario: Pre-run commands present
+- **WHEN** `PreRunCmds` contains install commands
+- **THEN** the exec args become `bash -c "PATH_SETUP; cmd1 && cmd2 ; exec agent_binary args"`
+
+#### Scenario: No pre-run commands
+- **WHEN** `PreRunCmds` is empty
+- **THEN** the exec args are the agent command directly (no bash wrapper)
+
+### Requirement: Shadow volume ownership
+After starting a new container, the system SHALL fix ownership of shadow `node_modules` volumes by running `chown` as root so the container user can write to them.
+
+#### Scenario: New container with shadow volumes
+- **WHEN** a container is started for a project with Node.js package.json files
+- **THEN** each shadow volume directory is chowned to `claude:claude`
+
+#### Scenario: Existing running container
+- **WHEN** the container is already running
+- **THEN** no chown is performed (it was done at first start)

--- a/openspec/changes/archive/2026-03-23-auto-install-node-modules/tasks.md
+++ b/openspec/changes/archive/2026-03-23-auto-install-node-modules/tasks.md
@@ -1,0 +1,28 @@
+## 1. Lockfile detection and prompt
+
+- [x] 1.1 Implement `nodeInstallCmds(projectDir)` — detect lockfiles via `FindNodeModulesDirs`, map to install commands
+- [x] 1.2 Consolidated prompt listing all projects with relative paths and install commands
+- [x] 1.3 Prompt uses `log.Info` with blank line for visibility after build output
+- [x] 1.4 Only prompt in agent mode, gated on `!FeatureOff("auto-install-node-modules")`
+
+## 2. Container exec integration
+
+- [x] 2.1 Add `PreRunCmds []string` to `ExecOpts`
+- [x] 2.2 Wrap agent command in `bash -c` with PATH/fnm setup when PreRunCmds non-empty
+- [x] 2.3 Add `shellJoin` helper for safe command quoting
+- [x] 2.4 Install failures are non-fatal (`;` before `exec agent`)
+
+## 3. Shadow volume ownership
+
+- [x] 3.1 Add `docker.Exec(container, user, command...)` helper
+- [x] 3.2 After container start, chown each shadow volume to `claude:claude` as root
+- [x] 3.3 Only runs on new container creation (inside `!docker.IsRunning` block)
+
+## 4. Changelog
+
+- [x] 4.1 Add entry under Unreleased
+
+## 5. Verification
+
+- [x] 5.1 Run `go test ./...` and `go vet ./...`
+- [x] 5.2 Manual test: run asylum on Node.js project, verify prompt appears and deps install

--- a/openspec/changes/archive/2026-03-23-project-onboarding/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-23-project-onboarding/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-20

--- a/openspec/changes/archive/2026-03-23-project-onboarding/design.md
+++ b/openspec/changes/archive/2026-03-23-project-onboarding/design.md
@@ -1,0 +1,144 @@
+## Context
+
+Asylum currently handles Node.js dependency installation through a fragile chain: Go prompts the user, passes install commands as `PreRunCmds`, which wraps the agent command in `bash -c` with duplicated PATH setup. This is hard to extend and mixes concerns. Shadow volume ownership is fixed in the entrypoint, which is a separate concern (container setup) and stays there.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Clean separation: scan → prompt → execute, all in Go.
+- Extensible: adding a new task (Python, credentials) means adding a struct, not modifying dispatch logic.
+- State tracking: don't re-prompt for completed tasks unless inputs change.
+- Controllable: global disable, per-task disable, CLI skip flag.
+
+**Non-Goals:**
+- Task dependencies (not needed yet — tasks are independent).
+- Running onboarding in non-agent modes (shell/run users handle setup themselves).
+- Shadow volume ownership (that's container setup, stays in entrypoint).
+
+## Decisions
+
+### 1. Task interface
+
+Each onboarding task is a Go struct implementing:
+
+```go
+type Task interface {
+    Name() string
+    Detect(projectDir string) []Workload
+}
+
+type Workload struct {
+    Label      string   // display name, e.g. "eamportal-view/.../angular"
+    Command    []string // e.g. ["pnpm", "install", "--frozen-lockfile"]
+    Dir        string   // working directory inside container
+    HashInputs []string // paths to files whose hash determines re-run (e.g. lockfile)
+    Phase      Phase    // PostContainer (PreContainer reserved for future use)
+}
+```
+
+`Detect` returns zero or more workloads. Each workload has its own hash inputs for change detection. Per-task disable is handled centrally in `Run()` by checking `opts.Onboarding[task.Name()]` — no need for a separate `FeatureFlag` method since the task name is the key.
+
+**Why workloads separate from tasks?** A single "npm" task can produce multiple workloads (one per package.json in a monorepo). The task decides detection logic; the framework handles prompting, state, and execution uniformly.
+
+### 2. Orchestration in main.go
+
+The onboarding runs between container start and session exec:
+
+```
+container started (or already running)
+    │
+    ▼
+onboarding.Run(opts)
+    ├── load state from ~/.asylum/projects/<cname>/onboarding.json
+    ├── for each registered task:
+    │     ├── check feature flag → skip if disabled
+    │     ├── task.Detect(projectDir) → workloads
+    │     ├── for each workload:
+    │     │     └── compare hash → skip if unchanged
+    │     └── collect pending workloads
+    ├── if no pending workloads → return
+    ├── prompt user (consolidated list)
+    ├── if declined → return
+    ├── execute accepted workloads:
+    │     ├── PreContainer: exec on host (future)
+    │     └── PostContainer: docker exec into container
+    ├── save updated state
+    └── return
+    │
+    ▼
+docker exec agent/shell/command
+```
+
+### 3. Execution via docker exec from Go
+
+Post-container tasks run via `docker.Exec(container, user, cmd...)` — the helper we already have. The Go process captures stdout/stderr and streams it to the user's terminal. Errors are reported but non-fatal: a failed install doesn't prevent the agent from starting.
+
+**Why not a bash wrapper?** Running `docker exec` per workload from Go gives us:
+- Individual error handling per workload
+- Clean agent command (no `bash -c` wrapper)
+- PATH setup handled once in the exec command, not duplicated
+
+**PATH resolution**: `docker exec` inherits the container's initial environment, not the entrypoint's exports. The entrypoint sets up fnm, mise, and other tools that modify PATH dynamically. To make this available to `docker exec` calls:
+
+1. The entrypoint writes its final resolved PATH to `/tmp/asylum-path` after all setup is complete.
+2. `WaitReady` polls for this marker file, ensuring the entrypoint has finished before Go proceeds.
+3. Before running onboarding tasks, Go reads the file via `docker exec cat /tmp/asylum-path`.
+4. Each onboarding `docker exec` runs through `bash -c "export PATH=<resolved>; <command>"` — this ensures PATH is applied before command lookup in the same process (using `-e PATH=` alone would not work because Docker resolves the executable before applying environment variables).
+
+This avoids duplicating PATH knowledge in Go and stays correct as the Dockerfile/entrypoint evolve.
+
+### 4. State persistence
+
+State lives at `~/.asylum/projects/<container-name>/onboarding.json`:
+
+```json
+{
+  "auto-install-node-modules": {
+    "eamportal-view/.../angular": "sha256:abc123",
+    "eamportal-admintool/.../build": "sha256:def456"
+  }
+}
+```
+
+Keys are task names (matching feature flags). Values are maps of workload label → hash of inputs. On scan, if the hash matches, the workload is skipped. If the hash differs or the key is missing, the workload is pending.
+
+`--cleanup` wipes the projects directory (already does), which resets onboarding state.
+
+### 5. Skip mechanisms
+
+Three levels of control:
+
+| Mechanism | Scope | Effect |
+|-----------|-------|--------|
+| `--skip-onboarding` CLI flag | Single invocation | Skip all onboarding this run |
+| `features: { onboarding: false }` | Permanent (config) | Disable all onboarding |
+| `onboarding: { npm: false }` | Per-task (config) | Disable specific task |
+
+The `features` map handles broad system toggles. The `onboarding` map is a dedicated config section where each key is a task name and the value is a bool (default true). This keeps per-task config separate from system features.
+
+```yaml
+# Global disable
+features:
+  onboarding: false
+
+# Per-task disable
+onboarding:
+  npm: false
+```
+
+The CLI flag is checked first, then the global feature flag, then per-task config. The `onboarding` map follows the same merge semantics as `versions` — scalar last-wins per key.
+
+### 6. npm task implementation
+
+The npm task replaces the current `nodeInstallCmds` function and entrypoint install block:
+
+- **Detect**: Reuses `FindNodeModulesDirs` to find package.json locations, checks each for lockfiles (package-lock.json, pnpm-lock.yaml, yarn.lock, bun.lock/bun.lockb).
+- **Hash input**: The lockfile path. Hash changes when deps change.
+- **Phase**: PostContainer (needs Linux binaries).
+- **Command**: `npm ci`, `pnpm install --frozen-lockfile`, etc.
+
+## Risks / Trade-offs
+
+- **PATH in docker exec**: We need to pass the correct PATH explicitly on each `docker exec` call since it doesn't inherit entrypoint exports. This couples the onboarding package to the container's tool layout. Acceptable since we control both.
+- **State file corruption**: Concurrent sessions could race on onboarding.json. Mitigated by: onboarding only runs on first container creation (inside the `!docker.IsRunning` block), and the session counter prevents concurrent first-starts.
+- **No rollback**: If an onboarding task partially succeeds (installs some deps, fails on others), there's no undo. The state records the attempt, and re-running with `--cleanup` or changed lockfile will retry.

--- a/openspec/changes/archive/2026-03-23-project-onboarding/proposal.md
+++ b/openspec/changes/archive/2026-03-23-project-onboarding/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Project onboarding logic (Node.js dependency installation, volume ownership fixes, future credential import and Python env setup) is currently scattered across the entrypoint shell script, bash-c exec wrappers, and Go dispatch code. This makes it fragile, hard to extend, and difficult to handle errors properly. The entrypoint can't reliably prompt the user, the bash wrapper duplicates PATH setup, and there's no way to run pre-container tasks.
+
+We need a structured onboarding system in Go that scans the project, prompts once, and orchestrates tasks across the container lifecycle — with proper error handling, state tracking, and extensibility.
+
+## What Changes
+
+- **Onboarding framework**: A task-based system where each onboarding task (npm install, future pip install, credential import, etc.) implements a common interface with detection, prompting, and execution phases.
+- **Scan → Prompt → Execute flow**: On container creation, the system scans for applicable tasks, shows a consolidated prompt, then executes accepted tasks at the appropriate phase (pre-container or post-container via `docker exec`).
+- **Project-scoped state**: Completed tasks are tracked in `~/.asylum/projects/<container-name>/onboarding.json` with lockfile hashes so tasks are skipped on subsequent starts unless inputs change.
+- **npm install as first task**: The existing auto-install logic is refactored into an onboarding task, removing the bash wrapper and entrypoint hacks.
+- **Skip onboarding**: `--skip-onboarding` CLI flag and `features: { onboarding: false }` config option to disable all onboarding. Individual tasks can be disabled in a dedicated `onboarding` config section (e.g., `onboarding: { npm: false }`).
+
+## Capabilities
+
+### New Capabilities
+
+- `project-onboarding`: Framework for detecting, prompting, and executing project setup tasks across the container lifecycle. Includes task interface, state tracking, and consolidated user prompt.
+- `onboarding-npm`: Node.js dependency installation as an onboarding task — detects lockfiles, runs the appropriate package manager via `docker exec`.
+
+### Modified Capabilities
+
+- `cli-dispatch`: Main dispatch gains onboarding orchestration between container start and session exec. New `--skip-onboarding` flag.
+- `container-assembly`: `ExecArgs` no longer needs `PreRunCmds` / bash wrapper for agent mode.
+
+## Impact
+
+- **New package**: `internal/onboarding/` with task interface, scanner, state persistence, and npm task implementation.
+- **CLI dispatch**: `main.go` calls onboarding between container start and `docker exec` for the session.
+- **Entrypoint**: Node.js install block removed (volume ownership fix stays — it's container setup, not onboarding).
+- **Container exec**: Agent command is no longer wrapped in `bash -c` — runs directly.
+- **State storage**: New file `~/.asylum/projects/<container-name>/onboarding.json`.
+- **Config**: `features: { onboarding: false }` for global disable. New `onboarding` map in Config struct for per-task control (e.g., `onboarding: { npm: false }`).

--- a/openspec/changes/archive/2026-03-23-project-onboarding/specs/cli-dispatch/spec.md
+++ b/openspec/changes/archive/2026-03-23-project-onboarding/specs/cli-dispatch/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Flag parsing
+The CLI SHALL parse `-a/--agent`, `-p`, `-v`, `-e`, `--java`, `-n/--new`, `--skip-onboarding`, `--cleanup`, `--rebuild`, `--version`, and `-h/--help` flags. Unknown flags SHALL be passed through to the agent.
+
+#### Scenario: Known flags consumed
+- **WHEN** `asylum -a gemini -p 3000` is run
+- **THEN** agent is set to gemini, port 3000 is forwarded, no passthrough args
+
+#### Scenario: Unknown flags passed through
+- **WHEN** `asylum -a gemini -p "fix the bug"` is run
+- **THEN** `-p "fix the bug"` is passed to the agent as extra args
+
+#### Scenario: Version flag
+- **WHEN** `asylum --version` is run
+- **THEN** the CLI prints `asylum <version>` to stdout and exits with code 0
+
+#### Scenario: Skip onboarding flag
+- **WHEN** `asylum --skip-onboarding` is run
+- **THEN** the onboarding system is not invoked for this session

--- a/openspec/changes/archive/2026-03-23-project-onboarding/specs/container-assembly/spec.md
+++ b/openspec/changes/archive/2026-03-23-project-onboarding/specs/container-assembly/spec.md
@@ -1,0 +1,5 @@
+## REMOVED Requirements
+
+### Requirement: PreRunCmds in exec args
+**Reason**: Replaced by the onboarding framework which runs commands via separate `docker exec` calls from Go, not by wrapping the agent command in `bash -c`.
+**Migration**: Use onboarding tasks instead of `PreRunCmds`.

--- a/openspec/changes/archive/2026-03-23-project-onboarding/specs/onboarding-npm/spec.md
+++ b/openspec/changes/archive/2026-03-23-project-onboarding/specs/onboarding-npm/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Detect Node.js projects with lockfiles
+The npm onboarding task SHALL use `FindNodeModulesDirs` to locate package.json files and check each directory for a lockfile to determine the install command.
+
+#### Scenario: npm project
+- **WHEN** a directory contains `package-lock.json`
+- **THEN** a workload with command `npm ci` is returned
+
+#### Scenario: pnpm project
+- **WHEN** a directory contains `pnpm-lock.yaml`
+- **THEN** a workload with command `pnpm install --frozen-lockfile` is returned
+
+#### Scenario: yarn project
+- **WHEN** a directory contains `yarn.lock`
+- **THEN** a workload with command `yarn install --frozen-lockfile` is returned
+
+#### Scenario: bun project
+- **WHEN** a directory contains `bun.lock` or `bun.lockb`
+- **THEN** a workload with command `bun install --frozen-lockfile` is returned
+
+#### Scenario: No lockfile
+- **WHEN** a directory has `package.json` but no lockfile
+- **THEN** no workload is returned for that directory
+
+### Requirement: Lockfile hash for change detection
+Each workload SHALL use the lockfile content hash as its input hash, so dependencies are only reinstalled when the lockfile changes.
+
+#### Scenario: Lockfile unchanged
+- **WHEN** the stored hash matches the current lockfile
+- **THEN** the workload is skipped
+
+#### Scenario: Lockfile changed
+- **WHEN** the stored hash differs from the current lockfile
+- **THEN** the workload is pending and included in the prompt
+
+### Requirement: Per-task config
+The npm task SHALL be disabled when `onboarding: { npm: false }` is set in config.
+
+#### Scenario: Disabled
+- **WHEN** config has `onboarding: { npm: false }`
+- **THEN** no npm workloads are detected or prompted

--- a/openspec/changes/archive/2026-03-23-project-onboarding/specs/project-onboarding/spec.md
+++ b/openspec/changes/archive/2026-03-23-project-onboarding/specs/project-onboarding/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: Task detection
+The onboarding system SHALL scan the project directory using registered tasks and collect pending workloads. A workload is pending if it has no state record or its input hash has changed.
+
+#### Scenario: First run with detectable tasks
+- **WHEN** the project has lockfiles and no onboarding state exists
+- **THEN** all matching workloads are collected as pending
+
+#### Scenario: Subsequent run with unchanged inputs
+- **WHEN** onboarding state exists and lockfile hashes match
+- **THEN** no workloads are collected (all skipped)
+
+#### Scenario: Lockfile changed since last run
+- **WHEN** a lockfile hash differs from the stored state
+- **THEN** that workload is collected as pending
+
+#### Scenario: No detectable tasks
+- **WHEN** no registered task detects any workloads
+- **THEN** onboarding completes immediately with no prompt
+
+### Requirement: Consolidated user prompt
+When pending workloads exist, the system SHALL display all of them in a single prompt and ask for confirmation before executing.
+
+#### Scenario: User accepts
+- **WHEN** the user presses Enter or types anything other than "n"
+- **THEN** all pending workloads are executed
+
+#### Scenario: User declines
+- **WHEN** the user types "n" or "N"
+- **THEN** no workloads are executed and the session starts normally
+
+### Requirement: Workload execution via docker exec
+Post-container workloads SHALL be executed inside the running container via `docker exec` from the Go binary, with stdout/stderr streamed to the user's terminal.
+
+#### Scenario: Successful execution
+- **WHEN** a workload command succeeds
+- **THEN** its hash is saved to onboarding state
+
+#### Scenario: Failed execution
+- **WHEN** a workload command fails
+- **THEN** an error is shown to the user, state is not updated for that workload, and the session starts normally (non-fatal)
+
+### Requirement: State persistence
+Onboarding state SHALL be stored at `~/.asylum/projects/<container-name>/onboarding.json` with input hashes keyed by task name and workload label.
+
+#### Scenario: State saved after successful workload
+- **WHEN** a workload completes successfully
+- **THEN** its hash is written to onboarding.json
+
+#### Scenario: State cleared on cleanup
+- **WHEN** `asylum --cleanup` is run
+- **THEN** onboarding state is removed along with other project data
+
+### Requirement: Skip mechanisms
+Onboarding SHALL be skippable at three levels: CLI flag (`--skip-onboarding`), global config (`features: { onboarding: false }`), and per-task config (`onboarding: { <task-name>: false }`).
+
+#### Scenario: CLI flag skips all
+- **WHEN** `--skip-onboarding` is passed
+- **THEN** no task detection or prompting occurs
+
+#### Scenario: Global config disables all
+- **WHEN** config has `features: { onboarding: false }`
+- **THEN** no task detection or prompting occurs
+
+#### Scenario: Per-task config disables one task
+- **WHEN** config has `onboarding: { npm: false }`
+- **THEN** that task is skipped but other tasks still run
+
+### Requirement: Agent mode only
+Onboarding SHALL only run in agent mode, not in shell, admin shell, or run modes.
+
+#### Scenario: Shell mode
+- **WHEN** `asylum shell` is run
+- **THEN** no onboarding occurs
+
+#### Scenario: Agent mode
+- **WHEN** `asylum` is run in agent mode
+- **THEN** onboarding runs between container start and agent exec
+
+### Requirement: Only on first container start
+Onboarding SHALL only run when a new container is created, not when exec'ing into an already-running container.
+
+#### Scenario: New container
+- **WHEN** no container is running and one is created
+- **THEN** onboarding runs after the container is ready
+
+#### Scenario: Existing container
+- **WHEN** the container is already running (second session)
+- **THEN** onboarding is skipped

--- a/openspec/changes/archive/2026-03-23-project-onboarding/tasks.md
+++ b/openspec/changes/archive/2026-03-23-project-onboarding/tasks.md
@@ -1,0 +1,48 @@
+## 1. Onboarding framework
+
+- [x] 1.1 Create `internal/onboarding/` package with `Task` interface and `Workload` struct
+- [x] 1.2 Implement `Run(opts)` orchestrator: load state → detect → prompt → execute → save state
+- [x] 1.3 Implement state persistence: load/save `~/.asylum/projects/<cname>/onboarding.json`
+- [x] 1.4 Implement input hashing: SHA-256 of file contents for change detection
+- [x] 1.5 Implement consolidated prompt: list pending workloads, single Y/n confirmation
+- [x] 1.6 Implement workload execution via `docker exec` with streamed output
+- [x] 1.7 Add tests for state load/save, hash comparison, and orchestrator logic
+
+## 2. PATH resolution for docker exec
+
+- [x] 2.1 Add `echo "$PATH" > /tmp/asylum-path` at end of entrypoint setup (before sleep)
+- [x] 2.2 Implement `docker.ReadFile(container, path)` helper to read `/tmp/asylum-path`
+- [x] 2.3 Pass `-e PATH=<resolved>` on onboarding `docker exec` calls
+
+## 3. npm onboarding task
+
+- [x] 3.1 Implement npm task struct: `Detect` using `FindNodeModulesDirs` + lockfile check
+- [x] 3.2 Map lockfiles to install commands (npm ci, pnpm, yarn, bun)
+- [x] 3.3 Use lockfile path as hash input
+- [x] 3.4 Per-task config: `onboarding: { npm: false }` (checked in `Run()` via `opts.Onboarding`)
+- [x] 3.5 Add tests for detection with various lockfile combinations
+
+## 4. CLI integration
+
+- [x] 4.1 Add `--skip-onboarding` flag to `parseArgs` and `cliFlags`
+- [x] 4.2 Call `onboarding.Run()` in `main()` between container start and session exec, agent mode only
+- [x] 4.3 Add `Onboarding map[string]bool` field to Config struct with map merge semantics
+- [x] 4.4 Check global `features: { onboarding: false }` and per-task `onboarding: { <name>: false }` before running
+- [x] 4.5 Add `--skip-onboarding` to `printUsage()` help text
+- [x] 4.6 Add test cases for `--skip-onboarding` flag parsing and onboarding config merging
+
+## 5. Remove old auto-install plumbing
+
+- [x] 5.1 Remove `PreRunCmds` from `ExecOpts` and bash wrapper from `ExecArgs`
+- [x] 5.2 Remove `shellJoin` helper
+- [x] 5.3 Remove `nodeInstallCmds` / `promptNodeInstall` from `main.go`
+- [x] 5.4 Remove Node.js install block from entrypoint.sh (if still present)
+- [x] 5.5 Update changelog
+
+## 6. Verification
+
+- [x] 6.1 Run `go test ./...` and `go vet ./...`
+- [x] 6.2 Manual test: first run prompts, installs, records state
+- [x] 6.3 Manual test: second run skips (same lockfile hash)
+- [x] 6.4 Manual test: `--skip-onboarding` suppresses prompt
+- [x] 6.5 Manual test: `onboarding: { npm: false }` disables npm task

--- a/openspec/specs/cli-dispatch/spec.md
+++ b/openspec/specs/cli-dispatch/spec.md
@@ -1,7 +1,7 @@
 ## ADDED Requirements
 
 ### Requirement: Flag parsing
-The CLI SHALL parse `-a/--agent`, `-p`, `-v`, `--java`, `-n/--new`, `--cleanup`, `--rebuild`, `--version`, and `-h/--help` flags. Unknown flags SHALL be passed through to the agent.
+The CLI SHALL parse `-a/--agent`, `-p`, `-v`, `-e`, `--java`, `-n/--new`, `--skip-onboarding`, `--cleanup`, `--rebuild`, `--version`, and `-h/--help` flags. Unknown flags SHALL be passed through to the agent.
 
 #### Scenario: Known flags consumed
 - **WHEN** `asylum -a gemini -p 3000` is run
@@ -14,6 +14,10 @@ The CLI SHALL parse `-a/--agent`, `-p`, `-v`, `--java`, `-n/--new`, `--cleanup`,
 #### Scenario: Version flag
 - **WHEN** `asylum --version` is run
 - **THEN** the CLI prints `asylum <version>` to stdout and exits with code 0
+
+#### Scenario: Skip onboarding flag
+- **WHEN** `asylum --skip-onboarding` is run
+- **THEN** the onboarding system is not invoked for this session
 
 ### Requirement: Command dispatch
 The CLI SHALL dispatch to version display, agent mode (default), shell mode, ssh-init, cleanup, self-update, or arbitrary command based on flags and positional args.

--- a/openspec/specs/onboarding-npm/spec.md
+++ b/openspec/specs/onboarding-npm/spec.md
@@ -1,0 +1,42 @@
+## Requirements
+
+### Requirement: Detect Node.js projects with lockfiles
+The npm onboarding task SHALL use `FindNodeModulesDirs` to locate package.json files and check each directory for a lockfile to determine the install command.
+
+#### Scenario: npm project
+- **WHEN** a directory contains `package-lock.json`
+- **THEN** a workload with command `npm ci` is returned
+
+#### Scenario: pnpm project
+- **WHEN** a directory contains `pnpm-lock.yaml`
+- **THEN** a workload with command `pnpm install --frozen-lockfile` is returned
+
+#### Scenario: yarn project
+- **WHEN** a directory contains `yarn.lock`
+- **THEN** a workload with command `yarn install --frozen-lockfile` is returned
+
+#### Scenario: bun project
+- **WHEN** a directory contains `bun.lock` or `bun.lockb`
+- **THEN** a workload with command `bun install --frozen-lockfile` is returned
+
+#### Scenario: No lockfile
+- **WHEN** a directory has `package.json` but no lockfile
+- **THEN** no workload is returned for that directory
+
+### Requirement: Lockfile hash for change detection
+Each workload SHALL use the lockfile content hash as its input hash, so dependencies are only reinstalled when the lockfile changes.
+
+#### Scenario: Lockfile unchanged
+- **WHEN** the stored hash matches the current lockfile
+- **THEN** the workload is skipped
+
+#### Scenario: Lockfile changed
+- **WHEN** the stored hash differs from the current lockfile
+- **THEN** the workload is pending and included in the prompt
+
+### Requirement: Per-task config
+The npm task SHALL be disabled when `onboarding: { npm: false }` is set in config.
+
+#### Scenario: Disabled
+- **WHEN** config has `onboarding: { npm: false }`
+- **THEN** no npm workloads are detected or prompted

--- a/openspec/specs/project-onboarding/spec.md
+++ b/openspec/specs/project-onboarding/spec.md
@@ -1,0 +1,90 @@
+## Requirements
+
+### Requirement: Task detection
+The onboarding system SHALL scan the project directory using registered tasks and collect pending workloads. A workload is pending if it has no state record or its input hash has changed.
+
+#### Scenario: First run with detectable tasks
+- **WHEN** the project has lockfiles and no onboarding state exists
+- **THEN** all matching workloads are collected as pending
+
+#### Scenario: Subsequent run with unchanged inputs
+- **WHEN** onboarding state exists and lockfile hashes match
+- **THEN** no workloads are collected (all skipped)
+
+#### Scenario: Lockfile changed since last run
+- **WHEN** a lockfile hash differs from the stored state
+- **THEN** that workload is collected as pending
+
+#### Scenario: No detectable tasks
+- **WHEN** no registered task detects any workloads
+- **THEN** onboarding completes immediately with no prompt
+
+### Requirement: Consolidated user prompt
+When pending workloads exist, the system SHALL display all of them in a single prompt and ask for confirmation before executing.
+
+#### Scenario: User accepts
+- **WHEN** the user presses Enter or types anything other than "n"
+- **THEN** all pending workloads are executed
+
+#### Scenario: User declines
+- **WHEN** the user types "n" or "N"
+- **THEN** no workloads are executed and the session starts normally
+
+### Requirement: Workload execution via docker exec
+Post-container workloads SHALL be executed inside the running container via `docker exec` from the Go binary, with stdout/stderr streamed to the user's terminal.
+
+#### Scenario: Successful execution
+- **WHEN** a workload command succeeds
+- **THEN** its hash is saved to onboarding state
+
+#### Scenario: Failed execution
+- **WHEN** a workload command fails
+- **THEN** an error is shown to the user, state is not updated for that workload, and the session starts normally (non-fatal)
+
+### Requirement: State persistence
+Onboarding state SHALL be stored at `~/.asylum/projects/<container-name>/onboarding.json` with input hashes keyed by task name and workload label.
+
+#### Scenario: State saved after successful workload
+- **WHEN** a workload completes successfully
+- **THEN** its hash is written to onboarding.json
+
+#### Scenario: State cleared on cleanup
+- **WHEN** `asylum --cleanup` is run
+- **THEN** onboarding state is removed along with other project data
+
+### Requirement: Skip mechanisms
+Onboarding SHALL be skippable at three levels: CLI flag (`--skip-onboarding`), global config (`features: { onboarding: false }`), and per-task config (`onboarding: { <task-name>: false }`).
+
+#### Scenario: CLI flag skips all
+- **WHEN** `--skip-onboarding` is passed
+- **THEN** no task detection or prompting occurs
+
+#### Scenario: Global config disables all
+- **WHEN** config has `features: { onboarding: false }`
+- **THEN** no task detection or prompting occurs
+
+#### Scenario: Per-task config disables one task
+- **WHEN** config has `onboarding: { npm: false }`
+- **THEN** that task is skipped but other tasks still run
+
+### Requirement: Agent mode only
+Onboarding SHALL only run in agent mode, not in shell, admin shell, or run modes.
+
+#### Scenario: Shell mode
+- **WHEN** `asylum shell` is run
+- **THEN** no onboarding occurs
+
+#### Scenario: Agent mode
+- **WHEN** `asylum` is run in agent mode
+- **THEN** onboarding runs between container start and agent exec
+
+### Requirement: Only on first container start
+Onboarding SHALL only run when a new container is created, not when exec'ing into an already-running container.
+
+#### Scenario: New container
+- **WHEN** no container is running and one is created
+- **THEN** onboarding runs after the container is ready
+
+#### Scenario: Existing container
+- **WHEN** the container is already running (second session)
+- **THEN** onboarding is skipped


### PR DESCRIPTION
## Summary
- Detect package manager from lockfile (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `bun.lock`/`bun.lockb`) when `node_modules` is empty
- Interactive sessions: prompt `Run <cmd>? [Y/n]` (defaults to yes)
- Non-interactive sessions: print hint with `asylum shell` command to install manually

## Test plan
- [ ] `asylum shell` in a project with `package.json` + `package-lock.json` → prompted, Enter installs
- [ ] Same prompt, type `n` → skipped
- [ ] `asylum run` (non-interactive) → prints hint instead of installing
- [ ] Project without lockfile → no prompt or hint
- [ ] Restart container → prompt appears again (anonymous volume is gone)