### PR TITLE
Set COLORTERM and TERM env vars for proper color support in container

### DIFF
--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -187,6 +187,8 @@ func appendEnvVars(args []string, opts RunOpts) []string {
 	}
 
 	env("ASYLUM_DOCKER", "1")
+	env("COLORTERM", "truecolor")
+	env("TERM", "xterm-256color")
 	if !opts.Config.Feature("allow-agent-terminal-title") {
 		env("CLAUDE_CODE_DISABLE_TERMINAL_TITLE", "1")
 	}

--- a/internal/container/container_test.go
+++ b/internal/container/container_test.go
@@ -267,6 +267,8 @@ func TestAppendEnvVars(t *testing.T) {
 
 		for _, want := range []string{
 			"-e ASYLUM_DOCKER=1",
+			"-e COLORTERM=truecolor",
+			"-e TERM=xterm-256color",
 			"-e HISTFILE=/home/claude/.shell_history/zsh_history",
 			"-e HOST_PROJECT_DIR=/work/myproject",
 		} {


### PR DESCRIPTION
Add `truecolor` support.

See before/after screenshots:
- Color of Claude Code mascot
- Color gradient
- Color shades within status line

<img width="1011" height="470" alt="before" src="https://github.com/user-attachments/assets/aefced29-6763-4315-90da-7fc63c8de205" />
<img width="1014" height="502" alt="after" src="https://github.com/user-attachments/assets/ec676eb7-8474-4cd4-a0ca-1cf825560dfa" />
