### PR TITLE
Document chmod +x requirement for manual binary downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Asylum wraps Docker to give your AI coding agent a fully-equipped Linux environm
 curl -fsSL https://raw.githubusercontent.com/inventage-ai/asylum/main/install.sh | sh
 ```
 
-Or download a binary from the [releases page](https://github.com/inventage-ai/asylum/releases).
+Or download a binary from the [releases page](https://github.com/inventage-ai/asylum/releases) (you'll need to `chmod +x` it before use).
 
 **Requires:** [Docker](https://docs.docker.com/get-docker/) installed and running.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ Asylum wraps Docker to give [Claude Code](https://claude.ai) a full development 
 curl -fsSL https://raw.githubusercontent.com/inventage-ai/asylum/main/install.sh | sh
 ```
 
-Or download a binary from the [releases page](https://github.com/inventage-ai/asylum/releases) and put it in your PATH.
+Or download a binary from the [releases page](https://github.com/inventage-ai/asylum/releases) and put it in your PATH (you'll need to `chmod +x` it before use).
 
 **Requires**: [Docker](https://docs.docker.com/get-docker/) installed and running.
 


### PR DESCRIPTION
## Summary

- Add `chmod +x` note to install instructions in `README.md` and `docs/index.md` for users downloading binaries directly from the releases page

Closes #17