### PR TITLE
Fix shadow node_modules chown failing for non-claude users

### DIFF
--- a/cmd/asylum/main.go
+++ b/cmd/asylum/main.go
@@ -296,8 +296,9 @@ func main() {
 
 		// Fix ownership of shadow node_modules volumes (Docker creates them as root)
 		if !cfg.ShadowNodeModulesOff() {
+			uid := fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid())
 			for _, nm := range container.FindNodeModulesDirs(projectDir) {
-				docker.Exec(cname, "root", "chown", "claude", nm)
+				docker.Exec(cname, "root", "chown", uid, nm)
 			}
 		}
 


### PR DESCRIPTION
## Summary
- Shadow `node_modules` ownership fix hardcoded `chown "claude"`, but the container user is the host username (from `os.Getuid()`). When the host user isn't named `claude`, chown fails silently and the volume stays `root:root`, causing `EACCES` on `pnpm install` / `npm install`.
- Use numeric `UID:GID` instead, which always matches the container user.

Fixes #22

## Test plan
- [ ] Run asylum on a machine where host username is not `claude`
- [ ] Verify `node_modules` is owned by the correct user after container start
- [ ] Verify `pnpm install` / `npm install` succeeds without permission errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)