### PR TITLE
Fix kit skill mount failure with shared config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Java kit now honors the configured `versions` list instead of always installing JDK 17, 21, and 25 (#26)
 - Kit credential configuration in overlay config files (`.asylum`, `.asylum.local`) was silently dropped during config merge
 - Credential config changes did not trigger the stale container warning because kit credentials were excluded from the config hash
+- Kit-provided Claude skills (`agent-browser`, `ast-grep`) no longer create empty directories in the user's host `~/.claude/skills/` in shared agent-config mode. Skills are now staged under `/opt/asylum-skills` inside the container and loaded via `--add-dir`. Users may safely remove any existing empty `~/.claude/skills/agent-browser/` or `~/.claude/skills/ast-grep/` directories left over from previous versions. (#24, #25)
 
 ## 0.6.5 — 2026-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Project config files now accept a `.yaml` extension alias (`.asylum.yaml`, `.asylum.local.yaml`) so editors apply YAML syntax highlighting; `.asylum` and `.asylum.local` remain the defaults (#15)
+- Mount host `~/.agents` directory into the container in shared agent mode
 
 ### Changed
 - Ports kit now allocates starting at port 7001 instead of 10000 — most browsers block access to the 10000+ range. Projects with an existing allocation at or above 10000 are automatically reassigned a new range on their next session.

--- a/assets/asylum-reference.md
+++ b/assets/asylum-reference.md
@@ -132,6 +132,10 @@ kits:
     disabled: true
 ```
 
+### Kit-Provided Claude Skills
+
+Kits that bundle Claude Code skills (e.g. `agent-browser`, `ast-grep`) stage them inside the container at `/opt/asylum-skills/.claude/skills/<skill-name>/`. Asylum launches `claude` with `--add-dir /opt/asylum-skills`, and a shell wrapper installed by the entrypoint adds the same flag to any interactive `claude` invocation from a secondary shell — so skills are discoverable both ways without asylum touching `~/.claude/skills/`.
+
 ## Installing Additional Tools
 
 To install additional tools in the container, prefer system packages over shell build commands. Packages are cached by Docker's layer system and install faster on rebuilds.

--- a/assets/entrypoint.core
+++ b/assets/entrypoint.core
@@ -83,6 +83,25 @@ if [ -n "$HOST_PROJECT_DIR" ] && { [ -f "$HOST_PROJECT_DIR/.mcp.json" ] || [ -f 
     echo "MCP configuration detected."
 fi
 
+# Install a `claude` shell wrapper so interactive invocations pick up kit-provided skills.
+# The wrapper only adds --add-dir when /opt/asylum-skills holds at least one skill.
+for rc in "$HOME/.zshrc" "$HOME/.bashrc"; do
+    [ -f "$rc" ] || continue
+    if ! grep -q '# asylum-claude-wrapper' "$rc" 2>/dev/null; then
+        cat >> "$rc" <<'EOF'
+
+# asylum-claude-wrapper
+claude() {
+    if [ -d /opt/asylum-skills/.claude/skills ] && [ -n "$(ls -A /opt/asylum-skills/.claude/skills 2>/dev/null)" ]; then
+        command claude --add-dir /opt/asylum-skills "$@"
+    else
+        command claude "$@"
+    fi
+}
+EOF
+    fi
+done
+
 # Set terminal
 export TERM=xterm-256color
 

--- a/cmd/asylum/main.go
+++ b/cmd/asylum/main.go
@@ -11,13 +11,13 @@ import (
 
 	"github.com/inventage-ai/asylum/internal/agent"
 	"github.com/inventage-ai/asylum/internal/config"
-	"github.com/inventage-ai/asylum/internal/firstrun"
 	"github.com/inventage-ai/asylum/internal/container"
 	"github.com/inventage-ai/asylum/internal/docker"
+	"github.com/inventage-ai/asylum/internal/firstrun"
 	"github.com/inventage-ai/asylum/internal/image"
+	"github.com/inventage-ai/asylum/internal/kit"
 	"github.com/inventage-ai/asylum/internal/log"
 	"github.com/inventage-ai/asylum/internal/onboarding"
-	"github.com/inventage-ai/asylum/internal/kit"
 	"github.com/inventage-ai/asylum/internal/selfupdate"
 	"github.com/inventage-ai/asylum/internal/term"
 	"github.com/inventage-ai/asylum/internal/tui"
@@ -143,13 +143,13 @@ func main() {
 	}
 
 	cfg, err := config.Load(projectDir, config.CLIFlags{
-		Agent:    flags.Agent,
-		Kits: flags.Kits,
-		Agents:   flags.Agents,
-		Ports:    flags.Ports,
-		Volumes:  flags.Volumes,
-		Env:      flags.Env,
-		Java:     flags.Java,
+		Agent:   flags.Agent,
+		Kits:    flags.Kits,
+		Agents:  flags.Agents,
+		Ports:   flags.Ports,
+		Volumes: flags.Volumes,
+		Env:     flags.Env,
+		Java:    flags.Java,
 	}, kitSnippets)
 	if err != nil {
 		die("load config: %v", err)
@@ -348,6 +348,7 @@ func main() {
 		ExtraArgs:     extraArgs,
 		NewSession:    newSession,
 		Config:        cfg,
+		Kits:          allKits,
 	})
 
 	setTabTitle(cfg.TabTitle(), projectDir, agentName, containerMode)
@@ -362,19 +363,19 @@ func main() {
 }
 
 type cliFlags struct {
-	Agent    string
-	Kits *[]string
-	Agents   *[]string
-	Ports    []string
-	Volumes  []string
-	Env      map[string]string
-	Java     string
-	New      bool
-	Rebuild bool
-	Cleanup bool
-	Help    bool
-	Version bool
-	Short   bool
+	Agent          string
+	Kits           *[]string
+	Agents         *[]string
+	Ports          []string
+	Volumes        []string
+	Env            map[string]string
+	Java           string
+	New            bool
+	Rebuild        bool
+	Cleanup        bool
+	Help           bool
+	Version        bool
+	Short          bool
 	All            bool
 	Admin          bool
 	Dev            bool
@@ -1059,9 +1060,9 @@ func runOnboarding(cfg *config.Config, a agent.Agent, allKits []*kit.Kit, home s
 		steps = append(steps, tui.WizardStep{
 			Title:       "Credentials",
 			Description: "Allow the sandbox to access host credentials for private registries and repositories (scoped to what the project needs, where possible).",
-			Kind:       tui.StepMultiSelect,
-			Options:    options,
-			DefaultSel: preSelected,
+			Kind:        tui.StepMultiSelect,
+			Options:     options,
+			DefaultSel:  preSelected,
 		})
 		appliers = append(appliers, func(result tui.StepResult) {
 			cfgPath := filepath.Join(home, ".asylum", "config.yaml")

--- a/docs/kits/agent-browser.md
+++ b/docs/kits/agent-browser.md
@@ -8,7 +8,7 @@ Browser automation via [agent-browser](https://github.com/vercel-labs/agent-brow
 
 - **agent-browser** CLI for browser automation
 - **Chrome** (Chrome for Testing, installed via `agent-browser install`)
-- **Claude Code skill** — auto-mounted from the upstream project, teaching Claude the snapshot-ref interaction pattern
+- **Claude Code skill** — staged inside the container at `/opt/asylum-skills/.claude/skills/agent-browser/` and loaded via Claude's `--add-dir` flag, teaching Claude the snapshot-ref interaction pattern. Nothing is written to your host `~/.claude/`.
 
 ## Configuration
 

--- a/docs/kits/ast-grep.md
+++ b/docs/kits/ast-grep.md
@@ -7,7 +7,7 @@ AST-based code search, lint, and rewrite via [ast-grep](https://ast-grep.github.
 ## What's Included
 
 - **sg** — CLI for searching, linting, and rewriting code using abstract syntax tree patterns
-- **Claude Code skill** — auto-mounted from the upstream [agent-skill](https://github.com/ast-grep/agent-skill) project, teaching Claude how to write ast-grep rules
+- **Claude Code skill** — staged inside the container at `/opt/asylum-skills/.claude/skills/ast-grep/` and loaded via Claude's `--add-dir` flag, teaching Claude how to write ast-grep rules (sourced from the upstream [agent-skill](https://github.com/ast-grep/agent-skill) project). Nothing is written to your host `~/.claude/`.
 
 ## Configuration
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -10,6 +10,12 @@ import (
 	"github.com/inventage-ai/asylum/internal/config"
 )
 
+// CmdOpts carries context from the container layer into agent command
+// generation. Fields are optional; agents ignore what they don't use.
+type CmdOpts struct {
+	KitSkillsDir string // shared container path holding kit-provided Claude skills; empty means no skill kits active
+}
+
 type Agent interface {
 	Name() string
 	Binary() string
@@ -18,7 +24,7 @@ type Agent interface {
 	AsylumConfigDir() string
 	EnvVars() map[string]string
 	HasSession(configDir, projectPath string) bool
-	Command(resume bool, extraArgs []string) []string
+	Command(resume bool, extraArgs []string, opts CmdOpts) []string
 }
 
 var agents = map[string]Agent{}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -59,18 +59,22 @@ func TestClaudeCommand(t *testing.T) {
 		name      string
 		resume    bool
 		extra     []string
+		opts      CmdOpts
 		wantParts []string
 	}{
-		{"default with session", true, nil, []string{"claude", "--dangerously-skip-permissions", "--continue"}},
-		{"default no session", false, nil, []string{"claude", "--dangerously-skip-permissions"}},
-		{"new session", false, nil, []string{"claude", "--dangerously-skip-permissions"}},
-		{"with args resume", true, []string{"fix", "the", "bug"}, []string{"claude", "--dangerously-skip-permissions", "--continue", "'fix'", "'the'", "'bug'"}},
-		{"with args no resume", false, []string{"fix", "bug"}, []string{"claude", "--dangerously-skip-permissions", "'fix'", "'bug'"}},
+		{"default with session", true, nil, CmdOpts{}, []string{"claude", "--dangerously-skip-permissions", "--continue"}},
+		{"default no session", false, nil, CmdOpts{}, []string{"claude", "--dangerously-skip-permissions"}},
+		{"new session", false, nil, CmdOpts{}, []string{"claude", "--dangerously-skip-permissions"}},
+		{"with args resume", true, []string{"fix", "the", "bug"}, CmdOpts{}, []string{"claude", "--dangerously-skip-permissions", "--continue", "'fix'", "'the'", "'bug'"}},
+		{"with args no resume", false, []string{"fix", "bug"}, CmdOpts{}, []string{"claude", "--dangerously-skip-permissions", "'fix'", "'bug'"}},
+		{"skills dir no resume", false, nil, CmdOpts{KitSkillsDir: "/opt/asylum-skills"}, []string{"claude", "--dangerously-skip-permissions", "--add-dir", "/opt/asylum-skills"}},
+		{"skills dir with resume", true, nil, CmdOpts{KitSkillsDir: "/opt/asylum-skills"}, []string{"claude", "--dangerously-skip-permissions", "--continue", "--add-dir", "/opt/asylum-skills"}},
+		{"skills dir with args", true, []string{"fix"}, CmdOpts{KitSkillsDir: "/opt/asylum-skills"}, []string{"claude", "--dangerously-skip-permissions", "--continue", "--add-dir", "/opt/asylum-skills", "'fix'"}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd := a.Command(tt.resume, tt.extra)
+			cmd := a.Command(tt.resume, tt.extra, tt.opts)
 			assertZshWrapped(t, cmd, tt.wantParts)
 		})
 	}
@@ -91,10 +95,15 @@ func TestGeminiCommand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd := a.Command(tt.resume, tt.extra)
+			cmd := a.Command(tt.resume, tt.extra, CmdOpts{})
 			assertZshWrapped(t, cmd, tt.wantParts)
 		})
 	}
+
+	t.Run("ignores kit skills dir", func(t *testing.T) {
+		cmd := a.Command(false, nil, CmdOpts{KitSkillsDir: "/opt/asylum-skills"})
+		assertZshWrapped(t, cmd, []string{"gemini", "--yolo"})
+	})
 }
 
 func TestCodexCommand(t *testing.T) {
@@ -112,10 +121,23 @@ func TestCodexCommand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd := a.Command(tt.resume, tt.extra)
+			cmd := a.Command(tt.resume, tt.extra, CmdOpts{})
 			assertZshWrapped(t, cmd, tt.wantParts)
 		})
 	}
+
+	t.Run("ignores kit skills dir", func(t *testing.T) {
+		cmd := a.Command(false, nil, CmdOpts{KitSkillsDir: "/opt/asylum-skills"})
+		assertZshWrapped(t, cmd, []string{"codex", "--yolo"})
+	})
+}
+
+func TestOpencodeCommand(t *testing.T) {
+	a := Opencode{}
+	t.Run("ignores kit skills dir", func(t *testing.T) {
+		cmd := a.Command(false, nil, CmdOpts{KitSkillsDir: "/opt/asylum-skills"})
+		assertZshWrapped(t, cmd, []string{"opencode"})
+	})
 }
 
 func assertZshWrapped(t *testing.T, cmd []string, wantParts []string) {
@@ -255,21 +277,27 @@ func TestCodexHasSession(t *testing.T) {
 func TestEchoCommand(t *testing.T) {
 	a := Echo{}
 	t.Run("with args", func(t *testing.T) {
-		cmd := a.Command(false, []string{"hello", "world"})
+		cmd := a.Command(false, []string{"hello", "world"}, CmdOpts{})
 		if len(cmd) != 3 || cmd[0] != "echo" || cmd[1] != "hello" || cmd[2] != "world" {
 			t.Errorf("got %v, want [echo hello world]", cmd)
 		}
 	})
 	t.Run("without args", func(t *testing.T) {
-		cmd := a.Command(false, nil)
+		cmd := a.Command(false, nil, CmdOpts{})
 		if len(cmd) != 1 || cmd[0] != "echo" {
 			t.Errorf("got %v, want [echo]", cmd)
 		}
 	})
 	t.Run("resume ignored", func(t *testing.T) {
-		cmd := a.Command(true, []string{"test"})
+		cmd := a.Command(true, []string{"test"}, CmdOpts{})
 		if len(cmd) != 2 || cmd[0] != "echo" {
 			t.Errorf("resume should be ignored, got %v", cmd)
+		}
+	})
+	t.Run("ignores kit skills dir", func(t *testing.T) {
+		cmd := a.Command(false, nil, CmdOpts{KitSkillsDir: "/opt/asylum-skills"})
+		if len(cmd) != 1 || cmd[0] != "echo" {
+			t.Errorf("KitSkillsDir should be ignored, got %v", cmd)
 		}
 	})
 }

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -24,8 +24,8 @@ RUN curl -fsSL https://claude.ai/install.sh | bash && \
 
 type Claude struct{}
 
-func (Claude) Name() string             { return "claude" }
-func (Claude) Binary() string           { return "claude" }
+func (Claude) Name() string               { return "claude" }
+func (Claude) Binary() string             { return "claude" }
 func (Claude) NativeConfigDir() string    { return "~/.claude" }
 func (Claude) ContainerConfigDir() string { return "~/.claude" }
 func (Claude) AsylumConfigDir() string    { return "~/.asylum/agents/claude" }
@@ -53,10 +53,13 @@ func (Claude) HasSession(configDir, projectPath string) bool {
 	return false
 }
 
-func (Claude) Command(resume bool, extraArgs []string) []string {
+func (Claude) Command(resume bool, extraArgs []string, opts CmdOpts) []string {
 	parts := []string{"claude", "--dangerously-skip-permissions"}
 	if resume {
 		parts = append(parts, "--continue")
+	}
+	if opts.KitSkillsDir != "" {
+		parts = append(parts, "--add-dir", opts.KitSkillsDir)
 	}
 	parts = append(parts, term.ShellQuoteArgs(extraArgs)...)
 	return wrapZsh(strings.Join(parts, " "))

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -25,8 +25,8 @@ RUN bash -c 'export PATH="$HOME/.local/share/fnm:$PATH" && eval "$(fnm env)" && 
 
 type Codex struct{}
 
-func (Codex) Name() string             { return "codex" }
-func (Codex) Binary() string           { return "codex" }
+func (Codex) Name() string               { return "codex" }
+func (Codex) Binary() string             { return "codex" }
 func (Codex) NativeConfigDir() string    { return "~/.codex" }
 func (Codex) ContainerConfigDir() string { return "~/.codex" }
 func (Codex) AsylumConfigDir() string    { return "~/.asylum/agents/codex" }
@@ -56,7 +56,7 @@ func (c Codex) WriteMarker(configDir, projectPath string) error {
 	return os.WriteFile(filepath.Join(dir, ".has_session"), nil, 0644)
 }
 
-func (Codex) Command(resume bool, extraArgs []string) []string {
+func (Codex) Command(resume bool, extraArgs []string, _ CmdOpts) []string {
 	if resume {
 		if len(extraArgs) == 0 {
 			return wrapZsh("codex resume --last --yolo")

--- a/internal/agent/echo.go
+++ b/internal/agent/echo.go
@@ -7,14 +7,14 @@ func init() {
 // Echo is a minimal testing agent that runs the shell echo command.
 type Echo struct{}
 
-func (Echo) Name() string               { return "echo" }
-func (Echo) Binary() string             { return "echo" }
-func (Echo) NativeConfigDir() string    { return "" }
-func (Echo) ContainerConfigDir() string { return "/tmp/asylum-echo" }
-func (Echo) AsylumConfigDir() string    { return "~/.asylum/agents/echo" }
-func (Echo) EnvVars() map[string]string { return nil }
+func (Echo) Name() string                { return "echo" }
+func (Echo) Binary() string              { return "echo" }
+func (Echo) NativeConfigDir() string     { return "" }
+func (Echo) ContainerConfigDir() string  { return "/tmp/asylum-echo" }
+func (Echo) AsylumConfigDir() string     { return "~/.asylum/agents/echo" }
+func (Echo) EnvVars() map[string]string  { return nil }
 func (Echo) HasSession(_, _ string) bool { return false }
 
-func (Echo) Command(_ bool, extraArgs []string) []string {
+func (Echo) Command(_ bool, extraArgs []string, _ CmdOpts) []string {
 	return append([]string{"echo"}, extraArgs...)
 }

--- a/internal/agent/gemini.go
+++ b/internal/agent/gemini.go
@@ -24,8 +24,8 @@ RUN bash -c 'export PATH="$HOME/.local/share/fnm:$PATH" && eval "$(fnm env)" && 
 
 type Gemini struct{}
 
-func (Gemini) Name() string             { return "gemini" }
-func (Gemini) Binary() string           { return "gemini" }
+func (Gemini) Name() string               { return "gemini" }
+func (Gemini) Binary() string             { return "gemini" }
 func (Gemini) NativeConfigDir() string    { return "~/.gemini" }
 func (Gemini) ContainerConfigDir() string { return "~/.gemini" }
 func (Gemini) AsylumConfigDir() string    { return "~/.asylum/agents/gemini" }
@@ -60,7 +60,7 @@ func (Gemini) HasSession(configDir, projectPath string) bool {
 	return false
 }
 
-func (Gemini) Command(resume bool, extraArgs []string) []string {
+func (Gemini) Command(resume bool, extraArgs []string, _ CmdOpts) []string {
 	parts := []string{"gemini", "--yolo"}
 	if resume {
 		parts = append(parts, "--resume")

--- a/internal/agent/opencode.go
+++ b/internal/agent/opencode.go
@@ -32,7 +32,7 @@ func (Opencode) EnvVars() map[string]string { return nil }
 
 func (Opencode) HasSession(_, _ string) bool { return false }
 
-func (Opencode) Command(resume bool, extraArgs []string) []string {
+func (Opencode) Command(resume bool, extraArgs []string, _ CmdOpts) []string {
 	if resume {
 		log.Warn("opencode: resume not supported, starting fresh session")
 	}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -654,6 +654,7 @@ type ExecOpts struct {
 	ExtraArgs     []string
 	NewSession    bool
 	Config        config.Config
+	Kits          []*kit.Kit
 }
 
 func ExecArgs(opts ExecOpts) []string {
@@ -686,7 +687,11 @@ func agentCommand(opts ExecOpts) []string {
 		opts.ContainerName,
 	)
 	resume := err == nil && !opts.NewSession && opts.Agent.HasSession(configDir, opts.ProjectDir)
-	return opts.Agent.Command(resume, opts.ExtraArgs)
+	cmdOpts := agent.CmdOpts{}
+	if kit.AnyProvidesSkills(opts.Kits) {
+		cmdOpts.KitSkillsDir = "/opt/asylum-skills"
+	}
+	return opts.Agent.Command(resume, opts.ExtraArgs, cmdOpts)
 }
 
 // EnsureAgentConfig returns true if the config was freshly created (first run).

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -297,6 +297,14 @@ func coreVolumes(home, cname string, opts RunOpts) ([]kit.RunArg, error) {
 	}
 	vol(hostConfigDir, containerConfigDir, "")
 
+	// ~/.agents — shared agent registry (only in shared mode)
+	if opts.Config.AgentIsolation(opts.Agent.Name()) == "shared" {
+		agentsDir := filepath.Join(home, ".agents")
+		if dirExists(agentsDir) {
+			vol(agentsDir, agentsDir, "")
+		}
+	}
+
 	// Direnv
 	envrc := filepath.Join(opts.ProjectDir, ".envrc")
 	if fileExists(envrc) {

--- a/internal/container/container_test.go
+++ b/internal/container/container_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/inventage-ai/asylum/internal/agent"
 	"github.com/inventage-ai/asylum/internal/config"
 	"github.com/inventage-ai/asylum/internal/kit"
 )
@@ -25,8 +26,8 @@ type stubAgent struct {
 	nativeConfigDir string
 }
 
-func (s stubAgent) Name() string    { return "stub" }
-func (s stubAgent) Binary() string  { return "stub-bin" }
+func (s stubAgent) Name() string   { return "stub" }
+func (s stubAgent) Binary() string { return "stub-bin" }
 func (s stubAgent) NativeConfigDir() string {
 	if s.nativeConfigDir != "" {
 		return s.nativeConfigDir
@@ -40,13 +41,18 @@ func (s stubAgent) AsylumConfigDir() string {
 	}
 	return "~/.asylum/agents/stub"
 }
-func (s stubAgent) EnvVars() map[string]string            { return s.envVars }
-func (s stubAgent) HasSession(_, _ string) bool            { return s.hasSession }
-func (s stubAgent) Command(resume bool, extra []string) []string {
+func (s stubAgent) EnvVars() map[string]string  { return s.envVars }
+func (s stubAgent) HasSession(_, _ string) bool { return s.hasSession }
+func (s stubAgent) Command(resume bool, extra []string, opts agent.CmdOpts) []string {
+	prefix := "stub"
 	if resume {
-		return append([]string{"stub-resume"}, extra...)
+		prefix = "stub-resume"
 	}
-	return append([]string{"stub"}, extra...)
+	out := []string{prefix}
+	if opts.KitSkillsDir != "" {
+		out = append(out, "--add-dir", opts.KitSkillsDir)
+	}
+	return append(out, extra...)
 }
 
 // claudeStubAgent wraps stubAgent but returns "claude" for Name().
@@ -1374,5 +1380,3 @@ func TestGenerateSandboxRules_WithoutPorts(t *testing.T) {
 		t.Error("should not have Forwarded Ports section when no ports allocated")
 	}
 }
-
-

--- a/internal/kit/agent_browser.go
+++ b/internal/kit/agent_browser.go
@@ -29,8 +29,8 @@ RUN bash -c 'export PATH="$HOME/.local/share/fnm:$PATH" && eval "$(fnm env)" && 
 if [ "$(uname -m)" = "aarch64" ] && command -v chromium >/dev/null 2>&1; then
     export AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium
 fi
-# Mount agent-browser skill into Claude skills directory
-if [ -d /tmp/asylum-kit-skills-agent-browser ] && [ -d "$HOME/.claude" ]; then
+# Mount agent-browser skill into Claude skills directory (skip if already present, e.g. shared config)
+if [ -d /tmp/asylum-kit-skills-agent-browser ] && [ -d "$HOME/.claude" ] && [ ! -e "$HOME/.claude/skills/agent-browser" ] && [ ! -L "$HOME/.claude/skills/agent-browser" ]; then
     mkdir -p "$HOME/.claude/skills/agent-browser"
     sudo mount --bind /tmp/asylum-kit-skills-agent-browser "$HOME/.claude/skills/agent-browser"
 fi

--- a/internal/kit/agent_browser.go
+++ b/internal/kit/agent_browser.go
@@ -6,9 +6,9 @@ func init() {
 		Description:    "Browser automation via agent-browser",
 		DockerPriority: 34,
 		Tier:           TierOptIn,
-		Deps:        []string{"node"},
-		Tools:       []string{"agent-browser"},
-		NeedsMount:  true,
+		Deps:           []string{"node"},
+		Tools:          []string{"agent-browser"},
+		ProvidesSkills: true,
 		ConfigSnippet: `  # agent-browser:      # Browser automation via agent-browser
 `,
 		ConfigNodes:   configNodes("agent-browser", "Browser automation via agent-browser", nil),
@@ -21,18 +21,15 @@ RUN bash -c 'export PATH="$HOME/.local/share/fnm:$PATH" && eval "$(fnm env)" && 
     else \
         sudo env "PATH=$PATH" agent-browser install --with-deps; \
     fi'
-RUN bash -c 'export PATH="$HOME/.local/share/fnm:$PATH" && eval "$(fnm env)" && \
-    cd /tmp && npx skills add vercel-labs/agent-browser --skill agent-browser --yes --copy && \
-    mv .claude/skills/agent-browser /tmp/asylum-kit-skills-agent-browser' || true
+RUN sudo mkdir -p /opt/asylum-skills/.claude/skills && \
+    sudo chown -R "$(id -u):$(id -g)" /opt/asylum-skills && \
+    bash -c 'export PATH="$HOME/.local/share/fnm:$PATH" && eval "$(fnm env)" && \
+        cd /tmp && npx skills add vercel-labs/agent-browser --skill agent-browser --yes --copy && \
+        mv .claude/skills/agent-browser /opt/asylum-skills/.claude/skills/agent-browser' || true
 `,
 		EntrypointSnippet: `# On ARM64, point agent-browser at system Chromium
 if [ "$(uname -m)" = "aarch64" ] && command -v chromium >/dev/null 2>&1; then
     export AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium
-fi
-# Mount agent-browser skill into Claude skills directory (skip if already present, e.g. shared config)
-if [ -d /tmp/asylum-kit-skills-agent-browser ] && [ -d "$HOME/.claude" ] && [ ! -e "$HOME/.claude/skills/agent-browser" ] && [ ! -L "$HOME/.claude/skills/agent-browser" ]; then
-    mkdir -p "$HOME/.claude/skills/agent-browser"
-    sudo mount --bind /tmp/asylum-kit-skills-agent-browser "$HOME/.claude/skills/agent-browser"
 fi
 `,
 		RulesSnippet: `### Browser (agent-browser kit)

--- a/internal/kit/astgrep.go
+++ b/internal/kit/astgrep.go
@@ -20,8 +20,8 @@ RUN bash -c 'export PATH="$HOME/.local/share/fnm:$PATH" && eval "$(fnm env)" && 
     cd /tmp && npx skills add ast-grep/agent-skill --skill ast-grep --yes --copy && \
     mv .claude/skills/ast-grep /tmp/asylum-kit-skills-ast-grep' || true
 `,
-		EntrypointSnippet: `# Mount ast-grep skill into Claude skills directory
-if [ -d /tmp/asylum-kit-skills-ast-grep ] && [ -d "$HOME/.claude" ]; then
+		EntrypointSnippet: `# Mount ast-grep skill into Claude skills directory (skip if already present, e.g. shared config)
+if [ -d /tmp/asylum-kit-skills-ast-grep ] && [ -d "$HOME/.claude" ] && [ ! -e "$HOME/.claude/skills/ast-grep" ] && [ ! -L "$HOME/.claude/skills/ast-grep" ]; then
     mkdir -p "$HOME/.claude/skills/ast-grep"
     sudo mount --bind /tmp/asylum-kit-skills-ast-grep "$HOME/.claude/skills/ast-grep"
 fi

--- a/internal/kit/astgrep.go
+++ b/internal/kit/astgrep.go
@@ -6,9 +6,9 @@ func init() {
 		Description:    "AST-based code search, lint, and rewrite",
 		DockerPriority: 44,
 		Tier:           TierOptIn,
-		Deps:        []string{"node"},
-		Tools:       []string{"sg"},
-		NeedsMount:  true,
+		Deps:           []string{"node"},
+		Tools:          []string{"sg"},
+		ProvidesSkills: true,
 		ConfigSnippet: `  # ast-grep:           # AST-based code search (sg)
 `,
 		ConfigNodes:   configNodes("ast-grep", "AST-based code search (sg)", nil),
@@ -16,15 +16,11 @@ func init() {
 		DockerSnippet: `# Install ast-grep
 RUN bash -c 'export PATH="$HOME/.local/share/fnm:$PATH" && eval "$(fnm env)" && \
     npm install -g @ast-grep/cli'
-RUN bash -c 'export PATH="$HOME/.local/share/fnm:$PATH" && eval "$(fnm env)" && \
-    cd /tmp && npx skills add ast-grep/agent-skill --skill ast-grep --yes --copy && \
-    mv .claude/skills/ast-grep /tmp/asylum-kit-skills-ast-grep' || true
-`,
-		EntrypointSnippet: `# Mount ast-grep skill into Claude skills directory (skip if already present, e.g. shared config)
-if [ -d /tmp/asylum-kit-skills-ast-grep ] && [ -d "$HOME/.claude" ] && [ ! -e "$HOME/.claude/skills/ast-grep" ] && [ ! -L "$HOME/.claude/skills/ast-grep" ]; then
-    mkdir -p "$HOME/.claude/skills/ast-grep"
-    sudo mount --bind /tmp/asylum-kit-skills-ast-grep "$HOME/.claude/skills/ast-grep"
-fi
+RUN sudo mkdir -p /opt/asylum-skills/.claude/skills && \
+    sudo chown -R "$(id -u):$(id -g)" /opt/asylum-skills && \
+    bash -c 'export PATH="$HOME/.local/share/fnm:$PATH" && eval "$(fnm env)" && \
+        cd /tmp && npx skills add ast-grep/agent-skill --skill ast-grep --yes --copy && \
+        mv .claude/skills/ast-grep /opt/asylum-skills/.claude/skills/ast-grep' || true
 `,
 		RulesSnippet: `### ast-grep (ast-grep kit)
 ast-grep (` + "`sg`" + `) is installed for AST-based code search, linting, and rewriting. Use ` + "`sg run`" + ` to search with patterns, ` + "`sg scan`" + ` to lint, and ` + "`sg rewrite`" + ` to apply transformations. Patterns use ` + "`$VAR`" + ` for wildcards. Example: ` + "`sg run -p 'fmt.Errorf($MSG)' -l go`" + `.

--- a/internal/kit/kit.go
+++ b/internal/kit/kit.go
@@ -70,7 +70,7 @@ type CredentialOpts struct {
 	ProjectDir    string
 	HomeDir       string
 	ContainerName string
-	Isolation     string         // kit-specific isolation level from config
+	Isolation     string // kit-specific isolation level from config
 	Mode          CredentialMode
 	Explicit      []string // identifiers when Mode is CredentialExplicit
 }
@@ -97,32 +97,33 @@ const (
 // Kit groups all concerns for a tool or language: installation,
 // environment setup, caching, onboarding, and config defaults.
 type Kit struct {
-	Name              string
-	Description       string
-	DockerSnippet     string
-	EntrypointSnippet string
-	BannerLines       string            // shell commands for welcome banner version lines
-	RulesSnippet      string            // markdown fragment for sandbox rules file
-	Tools             []string          // commands this kit makes available
-	CacheDirs         map[string]string  // name → container path
-	OnboardingTasks   []onboarding.Task
-	SubKits           map[string]*Kit
-	Deps              []string // kit names this kit depends on
-	Tier              Tier              // activation tier (TierDefault, TierAlwaysOn, TierOptIn)
+	Name               string
+	Description        string
+	DockerSnippet      string
+	EntrypointSnippet  string
+	BannerLines        string            // shell commands for welcome banner version lines
+	RulesSnippet       string            // markdown fragment for sandbox rules file
+	Tools              []string          // commands this kit makes available
+	CacheDirs          map[string]string // name → container path
+	OnboardingTasks    []onboarding.Task
+	SubKits            map[string]*Kit
+	Deps               []string                                        // kit names this kit depends on
+	Tier               Tier                                            // activation tier (TierDefault, TierAlwaysOn, TierOptIn)
 	CredentialFunc     func(CredentialOpts) ([]CredentialMount, error) // optional credential provider
-	CredentialLabel    string            // display label for onboarding (e.g. "Java/Maven")
+	CredentialLabel    string                                          // display label for onboarding (e.g. "Java/Maven")
 	MountFunc          func(CredentialOpts) ([]CredentialMount, error) // volume mounts without credential UI
-	ContainerFunc      func(ContainerOpts) ([]RunArg, error)          // docker run args contributed at container creation
-	DockerSnippetFunc  func(*SnippetConfig) string                    // config-driven Docker snippet (overrides DockerSnippet)
-	RulesSnippetFunc   func(*SnippetConfig) string                    // config-driven rules snippet (overrides RulesSnippet)
-	EnvFunc            func(*SnippetConfig) map[string]string         // container env vars contributed by this kit
-	ProjectSnippetFunc func(*SnippetConfig) string                    // Dockerfile commands for the project image
-	Hidden             bool              // exclude from interactive selection UIs (config TUI, kit sync prompt, sandbox rules disabled list)
-	NeedsMount        bool              // kit uses mount --bind at runtime (requires SYS_ADMIN)
-	DockerPriority    int               // lower = earlier in Dockerfile (stable/expensive first); 0 means default (50)
-	ConfigSnippet     string            // YAML snippet for default config (indented at 2 spaces under kits:)
-	ConfigNodes       []*yaml.Node      // structured key+value nodes for kits mapping (len 2: key, value)
-	ConfigComment     string            // comment text for opt-in/always-on kits shown in config
+	ContainerFunc      func(ContainerOpts) ([]RunArg, error)           // docker run args contributed at container creation
+	DockerSnippetFunc  func(*SnippetConfig) string                     // config-driven Docker snippet (overrides DockerSnippet)
+	RulesSnippetFunc   func(*SnippetConfig) string                     // config-driven rules snippet (overrides RulesSnippet)
+	EnvFunc            func(*SnippetConfig) map[string]string          // container env vars contributed by this kit
+	ProjectSnippetFunc func(*SnippetConfig) string                     // Dockerfile commands for the project image
+	Hidden             bool                                            // exclude from interactive selection UIs (config TUI, kit sync prompt, sandbox rules disabled list)
+	NeedsMount         bool                                            // kit uses mount --bind at runtime (requires SYS_ADMIN)
+	ProvidesSkills     bool                                            // kit stages Claude skills under /opt/asylum-skills/.claude/skills/<name>/ at build time
+	DockerPriority     int                                             // lower = earlier in Dockerfile (stable/expensive first); 0 means default (50)
+	ConfigSnippet      string                                          // YAML snippet for default config (indented at 2 spaces under kits:)
+	ConfigNodes        []*yaml.Node                                    // structured key+value nodes for kits mapping (len 2: key, value)
+	ConfigComment      string                                          // comment text for opt-in/always-on kits shown in config
 }
 
 var registry = map[string]*Kit{}
@@ -338,6 +339,17 @@ func AggregateOnboardingTasks(kits []*Kit) []onboarding.Task {
 func AnyNeedsMount(kits []*Kit) bool {
 	for _, k := range kits {
 		if k.NeedsMount {
+			return true
+		}
+	}
+	return false
+}
+
+// AnyProvidesSkills reports whether any kit stages Claude skills under the
+// shared kit-skills root.
+func AnyProvidesSkills(kits []*Kit) bool {
+	for _, k := range kits {
+		if k.ProvidesSkills {
 			return true
 		}
 	}

--- a/openspec/changes/archive/2026-04-19-kit-skills-add-dir/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-19-kit-skills-add-dir/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-19

--- a/openspec/changes/archive/2026-04-19-kit-skills-add-dir/design.md
+++ b/openspec/changes/archive/2026-04-19-kit-skills-add-dir/design.md
@@ -1,0 +1,102 @@
+## Context
+
+Today two kits (`agent-browser`, `ast-grep`) deliver Claude Code skills by:
+
+1. At image-build time, invoking `npx skills add ... --copy` into a temporary working directory and moving the result to `/tmp/asylum-kit-skills-<name>`.
+2. At container-start time, running a `mkdir -p "$HOME/.claude/skills/<name>"` followed by `sudo mount --bind /tmp/asylum-kit-skills-<name> "$HOME/.claude/skills/<name>"`.
+
+`$HOME/.claude` inside the container is a bind mount. In **isolated/project** agent-config modes it maps to `~/.asylum/agents/claude/`, which is asylum-owned and invisible to the user — so pollution there is harmless. In **shared** mode, it maps to the user's real `~/.claude/` on the host. Every `mkdir -p` in shared mode creates a directory on the user's host filesystem that persists after the bind mount is torn down on container exit.
+
+PR #25 guards the `mkdir`+`mount` pair with `[ ! -e "$dest" ] && [ ! -L "$dest" ]`. This avoids the `mkdir` error when the host already has a skill (commonly a symlink into `~/.agents/`), but it introduces a second bug: on the *next* container start in non-shared mode the empty directory created by the *previous* run still exists, the guard short-circuits, and the bind mount never happens — so the skill silently disappears. It also still creates host pollution on the first shared-mode run when the skill isn't already installed on host.
+
+Claude Code supports `--add-dir <path>` and automatically loads skills from `<path>/.claude/skills/*` (per the Claude Code docs, "Skills from additional directories"). This lets us deliver kit-provided skills from a path asylum fully owns, without touching `$HOME/.claude/skills/` in any mode.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Deliver kit-provided Claude skills without `mkdir` or `mount --bind` against `$HOME/.claude/skills/`.
+- No creation of files or directories on the host's real `~/.claude/` in shared mode, for the two skill-providing kits.
+- Eliminate the second-container-start bug in PR #25's approach by removing the stateful `mkdir` artifact entirely.
+- Keep the user-facing behavior identical: both skills remain discoverable by Claude with no extra user action.
+- Remove `NeedsMount: true` from the two affected kits so they no longer require `SYS_ADMIN` capability on their account.
+
+**Non-Goals:**
+
+- Fixing shared-mode pollution from `cx` and `rtk` kits. Those mount non-skill artifacts (rules files, hooks, `RTK.md`, `settings.json` edits) and require a different fix — tracked in issue #29.
+- Removing the `~/.agents` host bind mount added in PR #25. It remains useful for users whose host-installed skills symlink into `~/.agents/`, independent of this mechanism.
+- Extending a general "kits contribute agent CLI args" hook system. This change adds a targeted single-contribution path for one flag (`--add-dir`); a general hook would be built when a second use case appears.
+- Supporting skill delivery via this mechanism for non-Claude agents. Skills and `--add-dir` are Claude-specific.
+- Cleaning up empty skill directories left in users' `~/.claude/skills/` by previous asylum versions. Documented in CHANGELOG; users clean up manually.
+
+## Decisions
+
+### Decision: Stage skills under a single shared container root
+
+**Choice:** All skill-providing kits stage their skill directory under `/opt/asylum-skills/.claude/skills/<skill-name>/` at image-build time. The agent launcher passes a single `--add-dir /opt/asylum-skills` regardless of how many skill-providing kits are active.
+
+**Rationale:** One root means one `--add-dir` flag regardless of kit count. Avoids any need for per-kit agent-arg contributions, deduplication logic, or a new Kit hook for contributing CLI args. The directory layout encodes the convention; no runtime assembly needed.
+
+**Alternatives considered:**
+- Per-kit `--add-dir /opt/asylum-skills/<name>`: would require collecting contributions from multiple kits and merging them into the agent command. More plumbing for zero user-visible benefit.
+- Leave files under `/tmp/asylum-kit-skills-<name>` and pass multiple `--add-dir` flags: same downside as above and stretches the `/tmp` convention into a permanent home for installed artifacts.
+
+### Decision: `ProvidesSkills bool` on Kit, not a function hook
+
+**Choice:** Add a plain `ProvidesSkills bool` field to `kit.Kit`. Set to `true` on `agent-browser` and `ast-grep`.
+
+**Rationale:** The signal is static (known at kit-registration time, not a function of config or runtime state). A bool matches existing static kit metadata like `NeedsMount`, `Hidden`, `Tools`. A function hook would be overfit for this one flag.
+
+**Alternatives considered:**
+- `AgentArgsFunc func(ContainerOpts) []string`: general hook for kits to contribute arbitrary agent args. Premature — we have one use case. Can be introduced later when a second kit needs to contribute a different flag.
+- Inferring skill provision from the kit's DockerSnippet staging path: fragile, implicit. A declarative bool is clearer.
+
+### Decision: Agent command gains active-kits context via options, not raw signatures
+
+**Choice:** The `Agent.Command` interface grows to accept (or receive via an options struct) a signal indicating whether skill kits are active. Concrete shape: extend the signature to `Command(resume bool, extraArgs []string, opts AgentCmdOpts)` where `AgentCmdOpts` carries a `KitSkillsDir string` (empty when no skill-providing kit is active; set to `/opt/asylum-skills` when one or more are).
+
+**Rationale:** Keeps the decision centralized in the agent implementation rather than smearing `--add-dir` across the container layer. Other agents (Gemini, Codex, OpenCode) ignore the field. Using an options struct is future-proof — more fields can be added without breaking the interface again.
+
+**Alternatives considered:**
+- Post-process the returned command in the container layer to inject `--add-dir`: separates the decision from the Claude-specific knowledge of the flag, which is worse encapsulation.
+- New `ClaudeCommand` method specific to Claude: other agents wouldn't need to implement it, but the container layer would then have to type-switch on agent type to know whether to call it. Worse.
+
+### Decision: Interactive `claude` inside the container uses a shell function/alias
+
+**Choice:** The entrypoint installs a zsh function (`claude` wrapper) that invokes the real `claude` binary with `--add-dir /opt/asylum-skills` prepended when the shared-skills dir exists. Implemented in the same shell-setup step where PATH and other env are configured.
+
+**Rationale:** The primary agent launch is done by asylum via `agent.Command`, but users also spawn `claude` directly from a secondary terminal inside the container. Without the wrapper, those invocations miss kit skills. A function is lightweight, introspectable (`which claude` shows it), and scoped to the container only.
+
+**Alternatives considered:**
+- Environment variable consumed by Claude (e.g. `CLAUDE_ADD_DIR`): no such variable exists in Claude Code.
+- Symlinking `claude` to a wrapper script: more files, no benefit over a function.
+- Asking users to remember the flag: unacceptable.
+
+### Decision: Gate the wrapper and the launch flag on directory existence, not on active-kit lookup
+
+**Choice:** Both the agent-launch code and the shell wrapper check whether `/opt/asylum-skills/.claude/skills` contains any entries before passing `--add-dir`. The container layer sets `opts.KitSkillsDir` based on the static active-kit list, but the shell wrapper runs in the container (no access to the kit list) and so uses a filesystem check.
+
+**Rationale:** Avoids passing `--add-dir` to a nonexistent directory when a user customizes the image. Also keeps the shell wrapper self-contained — no generated content from the kit build.
+
+**Alternatives considered:**
+- Hard-coding the flag in the wrapper always: Claude may warn about missing directories. Cheap to avoid.
+
+### Decision: Remove `NeedsMount: true` from `agent-browser` and `ast-grep`
+
+**Choice:** With bind-mount gone, both kits become capability-free. `NeedsMount` drives SYS_ADMIN `--cap-add`; without mount operations it's not needed.
+
+**Rationale:** Smaller capability surface per kit. `AnyNeedsMount` in the container layer continues to work unchanged — `cx` and `rtk` still set it, so containers that include them still get SYS_ADMIN.
+
+## Risks / Trade-offs
+
+- **[Risk]** Users running `claude` via an execution path that skips the wrapper (e.g. a `bash` shell instead of `zsh`, or a hardcoded absolute path `/usr/local/bin/claude`) miss kit skills. → **Mitigation:** Install the wrapper in both `.zshrc` and `.bashrc` setup, consistent with how other shell config is handled. Document the `/opt/asylum-skills` path in `assets/asylum-reference.md` so an advanced user can add the flag manually if needed.
+
+- **[Risk]** A future Claude Code release changes or removes `--add-dir` semantics. → **Mitigation:** The mechanism is a thin layer on top of a documented, officially supported flag. If it changes, the failure mode is "skills not loaded" — no corruption, no pollution. The broken case is observable and fixable.
+
+- **[Risk]** Previous asylum users already have empty `agent-browser/` and `ast-grep/` directories in their host `~/.claude/skills/`. Those are not cleaned up. → **Mitigation:** CHANGELOG note instructing users to remove them manually. Not worth building a cleanup routine.
+
+- **[Risk]** A different kit (`cx`, `rtk`, or future ones) might try to hand off skills but not declare `ProvidesSkills: true`. → **Mitigation:** None required — those kits don't provide Claude skills, they mount other artifacts. The bool is additive and declarative; kits opt in.
+
+- **[Trade-off]** The agent interface changes. All five agent implementations need to update their `Command` signature. This is a mechanical, one-time cost. The options struct leaves room for future additions without further interface churn.
+
+- **[Trade-off]** `/opt/asylum-skills` is a hardcoded convention. If a kit ever wanted a different skills root (e.g. plugins grouped by kit), it would need to conform. Fine for the current design; revisit if the convention proves too rigid.

--- a/openspec/changes/archive/2026-04-19-kit-skills-add-dir/proposal.md
+++ b/openspec/changes/archive/2026-04-19-kit-skills-add-dir/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Kits that provide Claude Code skills (`agent-browser`, `ast-grep`) currently deliver them by `mkdir -p "$HOME/.claude/skills/<name>"` in the entrypoint and bind-mounting a staged directory over the top. In `shared` agent-config mode — where `$HOME/.claude` is a bind mount of the user's real `~/.claude` on the host — this pollutes the host filesystem with empty skill directories that persist after the container exits, silently scribbling into the user's personal Claude directory. PR #25 attempts a fix but (a) guards the mount with a directory-existence check that breaks on the second container start because the `mkdir` artifact persists and the guard then skips the mount, and (b) the approach fundamentally cannot avoid creating the host-side directory in shared mode. Claude Code supports `--add-dir <path>` with automatic discovery of `<path>/.claude/skills/*`, which removes the need to touch `$HOME/.claude/skills/` at all.
+
+## What Changes
+
+- Add a `ProvidesSkills bool` field to `kit.Kit` indicating the kit stages one or more Claude skills.
+- Define a shared container path `/opt/asylum-skills/.claude/skills/<skill-name>/` where skill-providing kits stage their skills at image-build time.
+- `agent-browser` and `ast-grep` kits stop using `/tmp/asylum-kit-skills-<name>` and stop emitting the entrypoint `mkdir`+`mount --bind` logic; their `DockerSnippet` now stages directly under the shared root and `NeedsMount: true` is removed from both.
+- The Claude agent's launch command conditionally appends `--add-dir /opt/asylum-skills` when any active kit declares `ProvidesSkills: true`. The container layer passes that signal through to the agent command builder.
+- The entrypoint installs a `claude` shell wrapper (or alias) so that interactive invocations in a secondary shell inside the container also pick up `--add-dir /opt/asylum-skills`.
+- No change to the `~/.agents` host mount introduced by PR #25 — it remains valuable for users whose host-installed skills symlink into `~/.agents`, independent of this change.
+- Out of scope: the `cx` and `rtk` kits, which mount non-skill artifacts (`~/.claude/rules/cx.md`, hooks, `RTK.md`, `settings.json` edits) and have their own shared-mode pollution problem tracked in issue #29.
+
+## Capabilities
+
+### New Capabilities
+- `kit-skills-delivery`: the shared mechanism by which kits expose Claude Code skills to the container — a container-owned staging root and the agent-launch integration that makes Claude discover them.
+
+### Modified Capabilities
+- `browser-kit`: skill delivery switches from entrypoint bind-mount into `~/.claude/skills/agent-browser/` to build-time staging under `/opt/asylum-skills/.claude/skills/agent-browser/`, and the kit declares `ProvidesSkills: true` instead of `NeedsMount: true`.
+- `ast-grep-kit`: same change pattern as `browser-kit`.
+- `agent-interface`: Claude command generation conditionally appends `--add-dir /opt/asylum-skills` when any active kit provides skills.
+
+## Impact
+
+- **Code:** `internal/kit/kit.go` (new field), `internal/kit/agent_browser.go`, `internal/kit/astgrep.go` (DockerSnippet rewrite, snippet removals, field changes), `internal/agent/claude.go` and `internal/agent/agent.go` (command signature or options plumbing for the `--add-dir` decision), `internal/container/container.go` (feed kit list into agent command construction), `assets/entrypoint.core` (shell wrapper for interactive `claude`).
+- **Users:** In shared config mode, no more empty directories created in `~/.claude/skills/`. Existing empty directories from prior asylum versions remain on host until the user cleans them up manually; a CHANGELOG note will cover this. Non-shared-mode users see no functional change.
+- **Other agents (Gemini, Codex, OpenCode):** Unaffected. Skills are a Claude-only concept and the `--add-dir` flag is Claude-only.
+- **SYS_ADMIN / cap-add --cap-add SYS_ADMIN:** Still required by `cx` and `rtk`. No change to container capabilities from this proposal.
+- **Dependencies:** None added.

--- a/openspec/changes/archive/2026-04-19-kit-skills-add-dir/specs/agent-interface/spec.md
+++ b/openspec/changes/archive/2026-04-19-kit-skills-add-dir/specs/agent-interface/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: Claude command generation
+Claude SHALL generate commands per PLAN.md section 3.2 with `--dangerously-skip-permissions` and conditional `--continue`. When the container layer signals that at least one active kit declares `ProvidesSkills: true`, the generated command SHALL also include `--add-dir /opt/asylum-skills`.
+
+#### Scenario: Default with session
+- **WHEN** Command is called with resume=true, no extra args, and no skill kits active
+- **THEN** command includes `--dangerously-skip-permissions --continue` without `--add-dir`
+
+#### Scenario: Default without session
+- **WHEN** Command is called with resume=false, no extra args, and no skill kits active
+- **THEN** command includes `--dangerously-skip-permissions` without `--continue` or `--add-dir`
+
+#### Scenario: With extra args and resume
+- **WHEN** Command is called with resume=true, extra args `["fix the bug"]`, and no skill kits active
+- **THEN** command includes `--dangerously-skip-permissions --continue fix the bug` without `--add-dir`
+
+#### Scenario: With skill-providing kit active
+- **WHEN** Command is called with resume=false, no extra args, and the container layer signals a skill kit is active
+- **THEN** command includes `--dangerously-skip-permissions --add-dir /opt/asylum-skills`
+
+#### Scenario: With skill-providing kit active and resume
+- **WHEN** Command is called with resume=true, no extra args, and the container layer signals a skill kit is active
+- **THEN** command includes `--dangerously-skip-permissions --continue --add-dir /opt/asylum-skills`
+
+### Requirement: Agent interface
+The agent package SHALL define an Agent interface with methods: Name, Binary, NativeConfigDir, ContainerConfigDir, AsylumConfigDir, EnvVars, HasSession, Command — matching PLAN.md section 8. The `Command` method SHALL accept an options parameter that carries context from the container layer (e.g. the shared kit-skills directory path), so agent implementations can tailor their launch command accordingly.
+
+#### Scenario: Interface methods
+- **WHEN** an Agent implementation is used
+- **THEN** all interface methods return correct values per the agent profile table in PLAN.md section 3.1
+
+#### Scenario: Command receives kit-skills context
+- **WHEN** `Command` is called with an options value whose `KitSkillsDir` field is `/opt/asylum-skills`
+- **THEN** agent implementations that care about skills (Claude) act on it, and agents that do not (Gemini, Codex, Opencode, Echo) ignore it

--- a/openspec/changes/archive/2026-04-19-kit-skills-add-dir/specs/ast-grep-kit/spec.md
+++ b/openspec/changes/archive/2026-04-19-kit-skills-add-dir/specs/ast-grep-kit/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: ast-grep Claude Code skill delivery
+The kit SHALL generate the ast-grep Claude Code skill at image-build time using `npx skills add ast-grep/agent-skill` and stage it under the shared kit-skills root at `/opt/asylum-skills/.claude/skills/ast-grep/`. The kit SHALL set `ProvidesSkills: true` so the Claude agent launcher passes `--add-dir /opt/asylum-skills`. The kit SHALL NOT emit an entrypoint snippet that creates directories under `$HOME/.claude/skills/` or that bind-mounts the staged skill into `$HOME/.claude/skills/ast-grep/`.
+
+#### Scenario: Skill staged under shared root at build time
+- **WHEN** the Docker image is built with the ast-grep kit active
+- **THEN** `/opt/asylum-skills/.claude/skills/ast-grep/SKILL.md` exists in the image and contains the upstream skill content
+
+#### Scenario: Skill discoverable via --add-dir at runtime
+- **WHEN** the container starts with the ast-grep kit active and the configured agent is Claude
+- **THEN** the Claude launch command includes `--add-dir /opt/asylum-skills` and the skill is discoverable by Claude
+
+#### Scenario: Host ~/.claude/skills/ast-grep not created in shared mode
+- **WHEN** the container runs in shared agent-config mode and `~/.claude/skills/ast-grep/` does not exist on the host before the run
+- **THEN** after container exit, `~/.claude/skills/ast-grep/` still does not exist on the host

--- a/openspec/changes/archive/2026-04-19-kit-skills-add-dir/specs/browser-kit/spec.md
+++ b/openspec/changes/archive/2026-04-19-kit-skills-add-dir/specs/browser-kit/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: Claude Code skill generation
+The kit SHALL generate the agent-browser Claude Code skill at image-build time using `npx skills add vercel-labs/agent-browser` and stage it under the shared kit-skills root at `/opt/asylum-skills/.claude/skills/agent-browser/`. The kit SHALL set `ProvidesSkills: true` so the Claude agent launcher passes `--add-dir /opt/asylum-skills`. The kit SHALL NOT emit an entrypoint snippet that creates directories under `$HOME/.claude/skills/` or that bind-mounts the staged skill into `$HOME/.claude/skills/agent-browser/`.
+
+#### Scenario: Skill staged under shared root at build time
+- **WHEN** the Docker image is built with the agent-browser kit active
+- **THEN** `/opt/asylum-skills/.claude/skills/agent-browser/SKILL.md` exists in the image and contains the upstream skill content
+
+#### Scenario: Skill discoverable via --add-dir at runtime
+- **WHEN** the container starts with the agent-browser kit active and the configured agent is Claude
+- **THEN** the Claude launch command includes `--add-dir /opt/asylum-skills` and the skill is discoverable by Claude
+
+#### Scenario: Host ~/.claude/skills/agent-browser not created in shared mode
+- **WHEN** the container runs in shared agent-config mode and `~/.claude/skills/agent-browser/` does not exist on the host before the run
+- **THEN** after container exit, `~/.claude/skills/agent-browser/` still does not exist on the host

--- a/openspec/changes/archive/2026-04-19-kit-skills-add-dir/specs/kit-skills-delivery/spec.md
+++ b/openspec/changes/archive/2026-04-19-kit-skills-add-dir/specs/kit-skills-delivery/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: ProvidesSkills kit field
+The `kit.Kit` struct SHALL expose a `ProvidesSkills bool` field. Kits that stage one or more Claude Code skills for runtime use SHALL set this field to `true`.
+
+#### Scenario: Skill-providing kit declares ProvidesSkills
+- **WHEN** a kit such as `agent-browser` or `ast-grep` is registered
+- **THEN** its `ProvidesSkills` field is `true`
+
+#### Scenario: Non-skill kit leaves ProvidesSkills false
+- **WHEN** a kit that does not stage a Claude skill is registered (e.g. `docker`, `python`, `cx`, `rtk`)
+- **THEN** its `ProvidesSkills` field remains at the zero value `false`
+
+### Requirement: Shared skill staging root
+The system SHALL define `/opt/asylum-skills` as the single container-local root under which all skill-providing kits stage their skills. Each kit SHALL stage its skill into `/opt/asylum-skills/.claude/skills/<skill-name>/` at image-build time.
+
+#### Scenario: Kit stages skill under shared root
+- **WHEN** a kit with `ProvidesSkills: true` builds its Docker layer
+- **THEN** the resulting image contains the skill at `/opt/asylum-skills/.claude/skills/<skill-name>/SKILL.md` (and related files)
+
+#### Scenario: Multiple skill kits share one root
+- **WHEN** two or more kits with `ProvidesSkills: true` are active in the same image
+- **THEN** each kit's skill is present under `/opt/asylum-skills/.claude/skills/` as a sibling directory
+
+### Requirement: Skill-providing kits do not bind-mount into $HOME/.claude
+The system SHALL NOT generate entrypoint logic that creates directories under `$HOME/.claude/skills/` or that uses `mount --bind` to deliver skills. Skill delivery SHALL be exclusively via the shared staging root and `--add-dir`.
+
+#### Scenario: No mkdir against ~/.claude/skills in entrypoint
+- **WHEN** the assembled entrypoint script is inspected for a configuration that includes only skill-providing kits (no `cx` or `rtk`)
+- **THEN** the script contains no `mkdir -p "$HOME/.claude/skills/..."` and no `mount --bind` targeting `$HOME/.claude/skills/`
+
+#### Scenario: Host ~/.claude/skills untouched in shared mode
+- **WHEN** a container runs in shared agent-config mode with `agent-browser` and `ast-grep` active and the host's `~/.claude/skills/` does not contain `agent-browser/` or `ast-grep/` before the run
+- **THEN** after the container exits, `~/.claude/skills/agent-browser/` and `~/.claude/skills/ast-grep/` still do not exist on the host
+
+### Requirement: Agent launch passes --add-dir when skill kits are active
+The container layer SHALL communicate to the agent command builder whether any active kit declares `ProvidesSkills: true`. When at least one such kit is active and the agent is Claude, the generated launch command SHALL include `--add-dir /opt/asylum-skills`.
+
+#### Scenario: Skill kit active, Claude agent
+- **WHEN** the `agent-browser` kit is active and the configured agent is `claude`
+- **THEN** the generated agent launch command includes `--add-dir /opt/asylum-skills`
+
+#### Scenario: No skill kit active, Claude agent
+- **WHEN** no active kit has `ProvidesSkills: true` and the configured agent is `claude`
+- **THEN** the generated agent launch command does not include `--add-dir /opt/asylum-skills`
+
+#### Scenario: Skill kit active, non-Claude agent
+- **WHEN** a kit with `ProvidesSkills: true` is active and the configured agent is `gemini`, `codex`, `opencode`, or `echo`
+- **THEN** the generated agent launch command is unchanged (no `--add-dir` added)
+
+### Requirement: Interactive claude invocations pick up kit skills
+The container entrypoint SHALL install a shell wrapper (function or alias) named `claude` in both the zsh and bash startup files so that interactive invocations of `claude` from a secondary shell inside the container also receive `--add-dir /opt/asylum-skills` when the shared skills directory contains at least one skill.
+
+#### Scenario: Wrapper adds flag when skills are present
+- **WHEN** a user runs `claude` interactively in a secondary shell and `/opt/asylum-skills/.claude/skills` contains at least one entry
+- **THEN** the underlying invocation includes `--add-dir /opt/asylum-skills`
+
+#### Scenario: Wrapper does nothing when skills are absent
+- **WHEN** a user runs `claude` interactively and `/opt/asylum-skills/.claude/skills` is empty or does not exist
+- **THEN** the underlying invocation does not include `--add-dir /opt/asylum-skills`

--- a/openspec/changes/archive/2026-04-19-kit-skills-add-dir/tasks.md
+++ b/openspec/changes/archive/2026-04-19-kit-skills-add-dir/tasks.md
@@ -1,0 +1,45 @@
+## 1. Kit metadata
+
+- [x] 1.1 Add `ProvidesSkills bool` field to `kit.Kit` in `internal/kit/kit.go`, documented in the field comment
+- [x] 1.2 Add `AnyProvidesSkills(kits []*Kit) bool` helper in `internal/kit/kit.go` alongside `AnyNeedsMount`
+
+## 2. Agent interface
+
+- [x] 2.1 Define an `AgentCmdOpts` struct in `internal/agent/agent.go` carrying at least a `KitSkillsDir string` field (named `agent.CmdOpts` to avoid stutter)
+- [x] 2.2 Update `Agent` interface signature: `Command(resume bool, extraArgs []string, opts CmdOpts) []string`
+- [x] 2.3 Update `Claude.Command` in `internal/agent/claude.go` to prepend `--add-dir <opts.KitSkillsDir>` after `--dangerously-skip-permissions` when `opts.KitSkillsDir != ""`
+- [x] 2.4 Update `Gemini.Command`, `Codex.Command`, `Opencode.Command`, `Echo.Command` to accept the new `CmdOpts` parameter and ignore it
+- [x] 2.5 Update all callers of `Agent.Command` to pass `CmdOpts`; in `internal/container/container.go`, populate `KitSkillsDir` as `/opt/asylum-skills` when `kit.AnyProvidesSkills(opts.Kits)` is true, else empty
+- [x] 2.6 Extend `internal/agent/agent_test.go`: add test cases for Claude covering `KitSkillsDir=""` (no flag), `KitSkillsDir="/opt/asylum-skills"` with and without resume, with and without extra args; add coverage for Gemini/Codex/Opencode/Echo showing the new field is ignored
+
+## 3. agent-browser kit
+
+- [x] 3.1 Update `internal/kit/agent_browser.go`: set `ProvidesSkills: true`, remove `NeedsMount: true`
+- [x] 3.2 Replace the DockerSnippet line `mv .claude/skills/agent-browser /tmp/asylum-kit-skills-agent-browser` with staging into `/opt/asylum-skills/.claude/skills/agent-browser` (create parent dir first, chown to the container user so the skill is readable at runtime)
+- [x] 3.3 Remove the skill mount block from the EntrypointSnippet (keep the existing ARM64 `AGENT_BROWSER_EXECUTABLE_PATH` export)
+
+## 4. ast-grep kit
+
+- [x] 4.1 Update `internal/kit/astgrep.go`: set `ProvidesSkills: true`, remove `NeedsMount: true`
+- [x] 4.2 Replace the DockerSnippet line `mv .claude/skills/ast-grep /tmp/asylum-kit-skills-ast-grep` with staging into `/opt/asylum-skills/.claude/skills/ast-grep` (create parent dir first, chown to the container user)
+- [x] 4.3 Remove the EntrypointSnippet entirely (the mount block was its only content)
+
+## 5. Entrypoint shell wrapper
+
+- [x] 5.1 In `assets/entrypoint.core` (or the tail, whichever owns shell-setup writes), emit a `claude` shell function into both `$HOME/.zshrc` and `$HOME/.bashrc` that runs `command claude --add-dir /opt/asylum-skills "$@"` when `/opt/asylum-skills/.claude/skills` contains at least one entry, else `command claude "$@"`
+- [x] 5.2 Ensure the function is only installed once (guarded by a marker line) to survive repeated container starts (verified via local shell smoke test)
+- [x] 5.3 Manually verify inside a container that `type claude` shows the function and that `claude --help` still works without asylum launching it (verified against built image: wrapper function loads in interactive bash, dispatches with and without `--add-dir` depending on skills-dir state)
+
+## 6. Tests and verification
+
+- [x] 6.1 Run `go test ./...` and fix any failures caused by the `Agent.Command` signature change
+- [x] 6.2 Run `go vet ./...`
+- [x] 6.3 Build the base image with `agent-browser` and `ast-grep` active; verify `/opt/asylum-skills/.claude/skills/agent-browser/SKILL.md` and `/opt/asylum-skills/.claude/skills/ast-grep/SKILL.md` exist in the image (verified: both `SKILL.md` files present with upstream frontmatter)
+- [x] 6.4 Run asylum in non-shared mode; confirm Claude loads both skills (e.g. `/help` or running a skill-dependent command) (verified indirectly: wrapper dispatches `claude --add-dir /opt/asylum-skills` when skills dir is populated, and skills dir is populated in the built image)
+- [x] 6.5 Run asylum in shared mode with a clean host `~/.claude/skills/` (no `agent-browser/` or `ast-grep/` entries); confirm after exit that those entries are still absent on the host (verified: bind-mounted host `.claude/skills/` remained empty after a full entrypoint run against the built image)
+- [x] 6.6 Inside a running container, open a second shell, run `claude --help`, and confirm via `type claude` that the wrapper is active (verified: `type claude` in an interactive bash subshell inside the image reports the wrapper function)
+
+## 7. Documentation
+
+- [x] 7.1 Add a `CHANGELOG.md` entry under Unreleased → Fixed: "Kit-provided Claude skills (`agent-browser`, `ast-grep`) no longer create empty directories in the user's host `~/.claude/skills/` in shared agent-config mode. Skills are now staged under `/opt/asylum-skills` and loaded via `--add-dir`. Users may safely remove any existing empty `~/.claude/skills/agent-browser/` or `~/.claude/skills/ast-grep/` directories left over from previous versions. (#24, #25)"
+- [x] 7.2 Add a short section to `assets/asylum-reference.md` documenting `/opt/asylum-skills` as the kit-skills root and that `--add-dir` is set automatically by the `claude` wrapper

--- a/openspec/specs/agent-interface/spec.md
+++ b/openspec/specs/agent-interface/spec.md
@@ -1,11 +1,15 @@
 ## ADDED Requirements
 
 ### Requirement: Agent interface
-The agent package SHALL define an Agent interface with methods: Name, Binary, NativeConfigDir, ContainerConfigDir, AsylumConfigDir, EnvVars, HasSession, Command — matching PLAN.md section 8.
+The agent package SHALL define an Agent interface with methods: Name, Binary, NativeConfigDir, ContainerConfigDir, AsylumConfigDir, EnvVars, HasSession, Command — matching PLAN.md section 8. The `Command` method SHALL accept an options parameter that carries context from the container layer (e.g. the shared kit-skills directory path), so agent implementations can tailor their launch command accordingly.
 
 #### Scenario: Interface methods
 - **WHEN** an Agent implementation is used
 - **THEN** all interface methods return correct values per the agent profile table in PLAN.md section 3.1
+
+#### Scenario: Command receives kit-skills context
+- **WHEN** `Command` is called with an options value whose `KitSkillsDir` field is `/opt/asylum-skills`
+- **THEN** agent implementations that care about skills (Claude) act on it, and agents that do not (Gemini, Codex, Opencode, Echo) ignore it
 
 ### Requirement: Agent registry
 The agent package SHALL provide a Get function that returns an Agent by name ("claude", "gemini", "codex") or an error for unknown names.
@@ -19,19 +23,27 @@ The agent package SHALL provide a Get function that returns an Agent by name ("c
 - **THEN** it returns an error
 
 ### Requirement: Claude command generation
-Claude SHALL generate commands per PLAN.md section 3.2 with `--dangerously-skip-permissions` and conditional `--continue`.
+Claude SHALL generate commands per PLAN.md section 3.2 with `--dangerously-skip-permissions` and conditional `--continue`. When the container layer signals that at least one active kit declares `ProvidesSkills: true`, the generated command SHALL also include `--add-dir /opt/asylum-skills`.
 
 #### Scenario: Default with session
-- **WHEN** Command is called with resume=true and no extra args
-- **THEN** command includes `--dangerously-skip-permissions --continue`
+- **WHEN** Command is called with resume=true, no extra args, and no skill kits active
+- **THEN** command includes `--dangerously-skip-permissions --continue` without `--add-dir`
 
 #### Scenario: Default without session
-- **WHEN** Command is called with resume=false and no extra args
-- **THEN** command includes `--dangerously-skip-permissions` without `--continue`
+- **WHEN** Command is called with resume=false, no extra args, and no skill kits active
+- **THEN** command includes `--dangerously-skip-permissions` without `--continue` or `--add-dir`
 
 #### Scenario: With extra args and resume
-- **WHEN** Command is called with resume=true and extra args `["fix the bug"]`
-- **THEN** command includes `--dangerously-skip-permissions --continue fix the bug`
+- **WHEN** Command is called with resume=true, extra args `["fix the bug"]`, and no skill kits active
+- **THEN** command includes `--dangerously-skip-permissions --continue fix the bug` without `--add-dir`
+
+#### Scenario: With skill-providing kit active
+- **WHEN** Command is called with resume=false, no extra args, and the container layer signals a skill kit is active
+- **THEN** command includes `--dangerously-skip-permissions --add-dir /opt/asylum-skills`
+
+#### Scenario: With skill-providing kit active and resume
+- **WHEN** Command is called with resume=true, no extra args, and the container layer signals a skill kit is active
+- **THEN** command includes `--dangerously-skip-permissions --continue --add-dir /opt/asylum-skills`
 
 ### Requirement: Gemini command generation
 Gemini SHALL generate commands per PLAN.md section 3.2 with `--yolo` and conditional `--resume`.

--- a/openspec/specs/ast-grep-kit/spec.md
+++ b/openspec/specs/ast-grep-kit/spec.md
@@ -49,3 +49,18 @@ The kit SHALL provide a RulesSnippet describing ast-grep's availability and usag
 - **WHEN** sandbox rules are assembled with ast-grep kit active
 - **THEN** the rules file contains a section describing ast-grep and the `sg` command
 
+### Requirement: ast-grep Claude Code skill delivery
+The kit SHALL generate the ast-grep Claude Code skill at image-build time using `npx skills add ast-grep/agent-skill` and stage it under the shared kit-skills root at `/opt/asylum-skills/.claude/skills/ast-grep/`. The kit SHALL set `ProvidesSkills: true` so the Claude agent launcher passes `--add-dir /opt/asylum-skills`. The kit SHALL NOT emit an entrypoint snippet that creates directories under `$HOME/.claude/skills/` or that bind-mounts the staged skill into `$HOME/.claude/skills/ast-grep/`.
+
+#### Scenario: Skill staged under shared root at build time
+- **WHEN** the Docker image is built with the ast-grep kit active
+- **THEN** `/opt/asylum-skills/.claude/skills/ast-grep/SKILL.md` exists in the image and contains the upstream skill content
+
+#### Scenario: Skill discoverable via --add-dir at runtime
+- **WHEN** the container starts with the ast-grep kit active and the configured agent is Claude
+- **THEN** the Claude launch command includes `--add-dir /opt/asylum-skills` and the skill is discoverable by Claude
+
+#### Scenario: Host ~/.claude/skills/ast-grep not created in shared mode
+- **WHEN** the container runs in shared agent-config mode and `~/.claude/skills/ast-grep/` does not exist on the host before the run
+- **THEN** after container exit, `~/.claude/skills/ast-grep/` still does not exist on the host
+

--- a/openspec/specs/browser-kit/spec.md
+++ b/openspec/specs/browser-kit/spec.md
@@ -27,11 +27,19 @@ The kit SHALL provide a DockerSnippet that installs the agent-browser npm packag
 - **THEN** the `agent-browser` CLI is available and Chrome is installed
 
 ### Requirement: Claude Code skill generation
-The kit SHALL generate the agent-browser Claude Code skill at build time using `npx skills add vercel-labs/agent-browser` and mount it at runtime into `~/.claude/skills/agent-browser/SKILL.md`.
+The kit SHALL generate the agent-browser Claude Code skill at image-build time using `npx skills add vercel-labs/agent-browser` and stage it under the shared kit-skills root at `/opt/asylum-skills/.claude/skills/agent-browser/`. The kit SHALL set `ProvidesSkills: true` so the Claude agent launcher passes `--add-dir /opt/asylum-skills`. The kit SHALL NOT emit an entrypoint snippet that creates directories under `$HOME/.claude/skills/` or that bind-mounts the staged skill into `$HOME/.claude/skills/agent-browser/`.
 
-#### Scenario: Skill available in container
-- **WHEN** the container starts with the agent-browser kit active
-- **THEN** `~/.claude/skills/agent-browser/SKILL.md` exists and contains the upstream skill content
+#### Scenario: Skill staged under shared root at build time
+- **WHEN** the Docker image is built with the agent-browser kit active
+- **THEN** `/opt/asylum-skills/.claude/skills/agent-browser/SKILL.md` exists in the image and contains the upstream skill content
+
+#### Scenario: Skill discoverable via --add-dir at runtime
+- **WHEN** the container starts with the agent-browser kit active and the configured agent is Claude
+- **THEN** the Claude launch command includes `--add-dir /opt/asylum-skills` and the skill is discoverable by Claude
+
+#### Scenario: Host ~/.claude/skills/agent-browser not created in shared mode
+- **WHEN** the container runs in shared agent-config mode and `~/.claude/skills/agent-browser/` does not exist on the host before the run
+- **THEN** after container exit, `~/.claude/skills/agent-browser/` still does not exist on the host
 
 ### Requirement: agent-browser config snippet
 The kit SHALL provide a ConfigSnippet and ConfigNodes so that kit sync can add an `agent-browser` entry to the user's config file.

--- a/openspec/specs/kit-skills-delivery/spec.md
+++ b/openspec/specs/kit-skills-delivery/spec.md
@@ -1,0 +1,65 @@
+# kit-skills-delivery Specification
+
+## Purpose
+Defines the shared mechanism by which kits expose Claude Code skills to the container: a container-owned staging root at `/opt/asylum-skills` populated at image-build time, plus the agent-launch integration that makes Claude discover those skills via `--add-dir`.
+
+## Requirements
+
+### Requirement: ProvidesSkills kit field
+The `kit.Kit` struct SHALL expose a `ProvidesSkills bool` field. Kits that stage one or more Claude Code skills for runtime use SHALL set this field to `true`.
+
+#### Scenario: Skill-providing kit declares ProvidesSkills
+- **WHEN** a kit such as `agent-browser` or `ast-grep` is registered
+- **THEN** its `ProvidesSkills` field is `true`
+
+#### Scenario: Non-skill kit leaves ProvidesSkills false
+- **WHEN** a kit that does not stage a Claude skill is registered (e.g. `docker`, `python`, `cx`, `rtk`)
+- **THEN** its `ProvidesSkills` field remains at the zero value `false`
+
+### Requirement: Shared skill staging root
+The system SHALL define `/opt/asylum-skills` as the single container-local root under which all skill-providing kits stage their skills. Each kit SHALL stage its skill into `/opt/asylum-skills/.claude/skills/<skill-name>/` at image-build time.
+
+#### Scenario: Kit stages skill under shared root
+- **WHEN** a kit with `ProvidesSkills: true` builds its Docker layer
+- **THEN** the resulting image contains the skill at `/opt/asylum-skills/.claude/skills/<skill-name>/SKILL.md` (and related files)
+
+#### Scenario: Multiple skill kits share one root
+- **WHEN** two or more kits with `ProvidesSkills: true` are active in the same image
+- **THEN** each kit's skill is present under `/opt/asylum-skills/.claude/skills/` as a sibling directory
+
+### Requirement: Skill-providing kits do not bind-mount into $HOME/.claude
+The system SHALL NOT generate entrypoint logic that creates directories under `$HOME/.claude/skills/` or that uses `mount --bind` to deliver skills. Skill delivery SHALL be exclusively via the shared staging root and `--add-dir`.
+
+#### Scenario: No mkdir against ~/.claude/skills in entrypoint
+- **WHEN** the assembled entrypoint script is inspected for a configuration that includes only skill-providing kits (no `cx` or `rtk`)
+- **THEN** the script contains no `mkdir -p "$HOME/.claude/skills/..."` and no `mount --bind` targeting `$HOME/.claude/skills/`
+
+#### Scenario: Host ~/.claude/skills untouched in shared mode
+- **WHEN** a container runs in shared agent-config mode with `agent-browser` and `ast-grep` active and the host's `~/.claude/skills/` does not contain `agent-browser/` or `ast-grep/` before the run
+- **THEN** after the container exits, `~/.claude/skills/agent-browser/` and `~/.claude/skills/ast-grep/` still do not exist on the host
+
+### Requirement: Agent launch passes --add-dir when skill kits are active
+The container layer SHALL communicate to the agent command builder whether any active kit declares `ProvidesSkills: true`. When at least one such kit is active and the agent is Claude, the generated launch command SHALL include `--add-dir /opt/asylum-skills`.
+
+#### Scenario: Skill kit active, Claude agent
+- **WHEN** the `agent-browser` kit is active and the configured agent is `claude`
+- **THEN** the generated agent launch command includes `--add-dir /opt/asylum-skills`
+
+#### Scenario: No skill kit active, Claude agent
+- **WHEN** no active kit has `ProvidesSkills: true` and the configured agent is `claude`
+- **THEN** the generated agent launch command does not include `--add-dir /opt/asylum-skills`
+
+#### Scenario: Skill kit active, non-Claude agent
+- **WHEN** a kit with `ProvidesSkills: true` is active and the configured agent is `gemini`, `codex`, `opencode`, or `echo`
+- **THEN** the generated agent launch command is unchanged (no `--add-dir` added)
+
+### Requirement: Interactive claude invocations pick up kit skills
+The container entrypoint SHALL install a shell wrapper (function or alias) named `claude` in both the zsh and bash startup files so that interactive invocations of `claude` from a secondary shell inside the container also receive `--add-dir /opt/asylum-skills` when the shared skills directory contains at least one skill.
+
+#### Scenario: Wrapper adds flag when skills are present
+- **WHEN** a user runs `claude` interactively in a secondary shell and `/opt/asylum-skills/.claude/skills` contains at least one entry
+- **THEN** the underlying invocation includes `--add-dir /opt/asylum-skills`
+
+#### Scenario: Wrapper does nothing when skills are absent
+- **WHEN** a user runs `claude` interactively and `/opt/asylum-skills/.claude/skills` is empty or does not exist
+- **THEN** the underlying invocation does not include `--add-dir /opt/asylum-skills`


### PR DESCRIPTION
## Summary

- Skip entrypoint `mkdir` + `mount --bind` for kit skills when the skill directory already exists (e.g. shared config mode with skill pre-installed on host)
- Fixes both `agent-browser` and `ast-grep` kits

Fixes #24

## Test plan

- [ ] Build image with `shared` Claude config and `agent-browser` kit, with skill already installed on host — verify no `mkdir` error
- [ ] Build image with non-shared config and `agent-browser` kit — verify skill is still bind-mounted as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)