### PR TITLE
Fix Maven credential injection and add documentation  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+- Kit credential configuration in overlay config files (`.asylum`, `.asylum.local`) was silently dropped during config merge
+- Credential config changes did not trigger the stale container warning because kit credentials were excluded from the config hash
+
 ## 0.6.5 — 2026-04-01
 
 macOS binaries are now code-signed and notarized, eliminating Gatekeeper warnings for users downloading asylum from GitHub Releases. All release binaries now include SHA256 checksums and GitHub build provenance attestation for supply chain verification.

--- a/docs/kits/java.md
+++ b/docs/kits/java.md
@@ -58,7 +58,7 @@ kits:
 
 The filtered `settings.xml` is mounted read-only at `~/.m2/settings.xml` inside the container. If `~/.m2/settings.xml` does not exist on the host, or no referenced server IDs match, nothing is mounted. If a server ID is referenced in `pom.xml` but missing from `settings.xml`, a comment is added in its place in the generated file.
 
-Credentials are enabled via `asylum config` (interactive) or by editing `.asylum` directly.
+Credentials are enabled via `asylum config` (interactive) or by editing `.asylum` directly. Changes to credentials take effect on the next fresh container start — if a container is already running, use `asylum --rebuild` to apply them.
 
 ### java/gradle
 

--- a/docs/kits/java.md
+++ b/docs/kits/java.md
@@ -30,6 +30,36 @@ JDK 17, 21, and 25 are always pre-installed. You can install additional versions
 
 Installs Maven via apt. Dependency cache persisted at `~/.m2`.
 
+#### Maven Credentials
+
+The `java/maven` kit can inject credentials from your host's `~/.m2/settings.xml` into the container. Rather than mounting the full file, it generates a filtered `settings.xml` containing only the server entries that your project's `pom.xml` actually references — so unrelated credentials stay on the host.
+
+Configure credentials under the `java` kit:
+
+**Auto mode** (default when credentials are enabled): Asylum reads the `pom.xml` in your project root, extracts all referenced server IDs (from `repositories`, `pluginRepositories`, `distributionManagement`, and profiles), and injects the matching entries.
+
+```yaml
+kits:
+  java:
+    credentials: auto
+```
+
+**Explicit mode**: Specify server IDs directly, bypassing `pom.xml` discovery. Useful for multi-module projects or when the root `pom.xml` doesn't declare all repositories.
+
+```yaml
+kits:
+  java:
+    credentials:
+      - nexus-releases
+      - nexus-snapshots
+```
+
+**Disabling**: Set `credentials: false` to prevent any credential injection.
+
+The filtered `settings.xml` is mounted read-only at `~/.m2/settings.xml` inside the container. If `~/.m2/settings.xml` does not exist on the host, or no referenced server IDs match, nothing is mounted. If a server ID is referenced in `pom.xml` but missing from `settings.xml`, a comment is added in its place in the generated file.
+
+Credentials are enabled via `asylum config` (interactive) or by editing `.asylum` directly.
+
 ### java/gradle
 
 Installs Gradle via mise. Dependency cache persisted at `~/.gradle`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -416,6 +416,9 @@ func mergeKitConfig(base, overlay *KitConfig) *KitConfig {
 	if overlay.Count != 0 {
 		result.Count = overlay.Count
 	}
+	if overlay.Credentials != nil {
+		result.Credentials = overlay.Credentials
+	}
 	// Accumulating lists: concatenate
 	result.Packages = slices.Concat(base.Packages, overlay.Packages)
 	result.Build = slices.Concat(base.Build, overlay.Build)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -552,7 +552,7 @@ func ParseVolume(raw string, homeDir string) (Volume, error) {
 }
 
 // ConfigHash computes a deterministic hash of runtime-relevant config values
-// (volumes, env, ports) for detecting config drift against a running container.
+// (volumes, env, ports, kit credentials) for detecting config drift against a running container.
 func ConfigHash(cfg Config) string {
 	h := sha256.New()
 
@@ -570,6 +570,20 @@ func ConfigHash(cfg Config) string {
 	slices.Sort(ps)
 	for _, p := range ps {
 		fmt.Fprintf(h, "p:%s\n", p)
+	}
+
+	for _, kitName := range slices.Sorted(maps.Keys(cfg.Kits)) {
+		kc := cfg.Kits[kitName]
+		if kc == nil || kc.Credentials == nil {
+			continue
+		}
+		if kc.Credentials.Auto {
+			fmt.Fprintf(h, "c:%s=auto\n", kitName)
+		} else {
+			ids := slices.Clone(kc.Credentials.Explicit)
+			slices.Sort(ids)
+			fmt.Fprintf(h, "c:%s=%s\n", kitName, strings.Join(ids, ","))
+		}
 	}
 
 	return fmt.Sprintf("%x", h.Sum(nil))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 
@@ -44,19 +45,22 @@ func (c *Credentials) UnmarshalYAML(value *yaml.Node) error {
 }
 
 // KitConfig holds per-kit configuration options.
+// Fields tagged merge:"concat" are accumulated (base + overlay) during config
+// merge. All other fields use last-wins semantics (overlay replaces base when
+// non-zero). Adding a new field requires no merge code changes.
 type KitConfig struct {
 	Disabled            *bool        `yaml:"disabled,omitempty"`
 	Versions            []string     `yaml:"versions,omitempty"`
 	DefaultVersion      string       `yaml:"default-version,omitempty"`
-	Packages            []string     `yaml:"packages,omitempty"`
+	Packages            []string     `yaml:"packages,omitempty" merge:"concat"`
 	ShadowNodeModules   *bool        `yaml:"shadow-node-modules,omitempty"`
 	Onboarding          *bool        `yaml:"onboarding,omitempty"`
 	TabTitle            string       `yaml:"tab-title,omitempty"`
 	AllowAgentTermTitle *bool        `yaml:"allow-agent-terminal-title,omitempty"`
-	Build               []string     `yaml:"build,omitempty"`
+	Build               []string     `yaml:"build,omitempty" merge:"concat"`
 	Count               int          `yaml:"count,omitempty"`
 	Credentials         *Credentials `yaml:"credentials,omitempty"`
-	Isolation           string       `yaml:"isolation,omitempty"` // shared, isolated, project
+	Isolation           string       `yaml:"isolation,omitempty"`
 }
 
 // AgentConfig holds per-agent configuration.
@@ -385,8 +389,9 @@ func Merge(base, overlay Config) Config {
 	return result
 }
 
-// mergeKitConfig deep-merges two KitConfig values. Scalars use last-wins,
-// Packages and Build concatenate, Versions replaces.
+// mergeKitConfig deep-merges two KitConfig values using struct tags.
+// Fields tagged merge:"concat" are accumulated (base + overlay).
+// All other fields use last-wins: overlay replaces base when non-zero.
 func mergeKitConfig(base, overlay *KitConfig) *KitConfig {
 	if base == nil {
 		return overlay
@@ -395,36 +400,16 @@ func mergeKitConfig(base, overlay *KitConfig) *KitConfig {
 		return base
 	}
 	result := *base
-	if overlay.Disabled != nil {
-		result.Disabled = overlay.Disabled
-	}
-	if overlay.DefaultVersion != "" {
-		result.DefaultVersion = overlay.DefaultVersion
-	}
-	if overlay.ShadowNodeModules != nil {
-		result.ShadowNodeModules = overlay.ShadowNodeModules
-	}
-	if overlay.Onboarding != nil {
-		result.Onboarding = overlay.Onboarding
-	}
-	if overlay.TabTitle != "" {
-		result.TabTitle = overlay.TabTitle
-	}
-	if overlay.AllowAgentTermTitle != nil {
-		result.AllowAgentTermTitle = overlay.AllowAgentTermTitle
-	}
-	if overlay.Count != 0 {
-		result.Count = overlay.Count
-	}
-	if overlay.Credentials != nil {
-		result.Credentials = overlay.Credentials
-	}
-	// Accumulating lists: concatenate
-	result.Packages = slices.Concat(base.Packages, overlay.Packages)
-	result.Build = slices.Concat(base.Build, overlay.Build)
-	// Replacing list: last-wins
-	if overlay.Versions != nil {
-		result.Versions = overlay.Versions
+	rv := reflect.ValueOf(&result).Elem()
+	ov := reflect.ValueOf(overlay).Elem()
+	for i := range rv.NumField() {
+		of := ov.Field(i)
+		tag := rv.Type().Field(i).Tag.Get("merge")
+		if tag == "concat" {
+			rv.Field(i).Set(reflect.AppendSlice(rv.Field(i), of))
+		} else if !of.IsZero() {
+			rv.Field(i).Set(of)
+		}
 	}
 	return &result
 }
@@ -554,40 +539,24 @@ func ParseVolume(raw string, homeDir string) (Volume, error) {
 	}
 }
 
-// ConfigHash computes a deterministic hash of runtime-relevant config values
-// (volumes, env, ports, kit credentials) for detecting config drift against a running container.
+// ConfigHash computes a deterministic hash of the config for detecting drift
+// against a running container. It serializes the full config to YAML (which
+// sorts map keys deterministically) after clearing non-runtime fields and
+// normalizing order-insensitive lists. New fields are included automatically.
 func ConfigHash(cfg Config) string {
-	h := sha256.New()
+	// Clear fields that don't affect the running container.
+	cfg.Version = ""
+	cfg.Agent = ""
+	cfg.ReleaseChannel = ""
+	cfg.Agents = nil
 
-	vols := slices.Clone(cfg.Volumes)
-	slices.Sort(vols)
-	for _, v := range vols {
-		fmt.Fprintf(h, "v:%s\n", v)
+	// Sort order-insensitive lists so the hash is stable regardless of YAML order.
+	slices.Sort(cfg.Volumes)
+	slices.Sort(cfg.Ports)
+
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return ""
 	}
-
-	for _, k := range slices.Sorted(maps.Keys(cfg.Env)) {
-		fmt.Fprintf(h, "e:%s=%s\n", k, cfg.Env[k])
-	}
-
-	ps := slices.Clone(cfg.Ports)
-	slices.Sort(ps)
-	for _, p := range ps {
-		fmt.Fprintf(h, "p:%s\n", p)
-	}
-
-	for _, kitName := range slices.Sorted(maps.Keys(cfg.Kits)) {
-		kc := cfg.Kits[kitName]
-		if kc == nil || kc.Credentials == nil {
-			continue
-		}
-		if kc.Credentials.Auto {
-			fmt.Fprintf(h, "c:%s=auto\n", kitName)
-		} else {
-			ids := slices.Clone(kc.Credentials.Explicit)
-			slices.Sort(ids)
-			fmt.Fprintf(h, "c:%s=%s\n", kitName, strings.Join(ids, ","))
-		}
-	}
-
-	return fmt.Sprintf("%x", h.Sum(nil))
+	return fmt.Sprintf("%x", sha256.Sum256(data))
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -658,6 +658,26 @@ func TestMergeKitConfig(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "credentials overlay replaces base",
+			base: &KitConfig{Credentials: &Credentials{Auto: true}},
+			over: &KitConfig{Credentials: &Credentials{Explicit: []string{"nexus"}}},
+			check: func(t *testing.T, kc *KitConfig) {
+				if kc.Credentials == nil || kc.Credentials.Auto || len(kc.Credentials.Explicit) != 1 || kc.Credentials.Explicit[0] != "nexus" {
+					t.Errorf("credentials = %+v, want explicit [nexus]", kc.Credentials)
+				}
+			},
+		},
+		{
+			name: "absent credentials in overlay preserves base",
+			base: &KitConfig{Credentials: &Credentials{Auto: true}},
+			over: &KitConfig{},
+			check: func(t *testing.T, kc *KitConfig) {
+				if kc.Credentials == nil || !kc.Credentials.Auto {
+					t.Errorf("credentials = %+v, want auto", kc.Credentials)
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -784,6 +804,28 @@ func TestConfigHash(t *testing.T) {
 		}
 		if ConfigHash(a) != ConfigHash(b) {
 			t.Error("same values in different order should produce same hash")
+		}
+	})
+
+	t.Run("credential change detected", func(t *testing.T) {
+		auto := Config{Kits: map[string]*KitConfig{
+			"java": {Credentials: &Credentials{Auto: true}},
+		}}
+		explicit := Config{Kits: map[string]*KitConfig{
+			"java": {Credentials: &Credentials{Explicit: []string{"nexus"}}},
+		}}
+		if ConfigHash(auto) == ConfigHash(explicit) {
+			t.Error("different credential configs should produce different hashes")
+		}
+	})
+
+	t.Run("absent credentials do not contribute", func(t *testing.T) {
+		withNilCreds := Config{Kits: map[string]*KitConfig{
+			"java": nil,
+		}}
+		empty := Config{}
+		if ConfigHash(withNilCreds) != ConfigHash(empty) {
+			t.Error("nil credentials should not affect the hash")
 		}
 	})
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -819,13 +819,29 @@ func TestConfigHash(t *testing.T) {
 		}
 	})
 
-	t.Run("absent credentials do not contribute", func(t *testing.T) {
-		withNilCreds := Config{Kits: map[string]*KitConfig{
+	t.Run("nil kit config differs from absent kit", func(t *testing.T) {
+		withKit := Config{Kits: map[string]*KitConfig{
 			"java": nil,
 		}}
-		empty := Config{}
-		if ConfigHash(withNilCreds) != ConfigHash(empty) {
-			t.Error("nil credentials should not affect the hash")
+		without := Config{}
+		if ConfigHash(withKit) == ConfigHash(without) {
+			t.Error("declared kit (even with nil config) should differ from absent kit")
+		}
+	})
+
+	t.Run("non-runtime fields excluded", func(t *testing.T) {
+		base := Config{}
+		varied := Config{Agent: "claude", Version: "2", ReleaseChannel: "dev", Agents: map[string]*AgentConfig{"claude": {Config: "shared"}}}
+		if ConfigHash(base) != ConfigHash(varied) {
+			t.Error("non-runtime fields (Agent, Version, ReleaseChannel, Agents) should not affect hash")
+		}
+	})
+
+	t.Run("new kit config fields included automatically", func(t *testing.T) {
+		without := Config{Kits: map[string]*KitConfig{"java": {}}}
+		with := Config{Kits: map[string]*KitConfig{"java": {Isolation: "project"}}}
+		if ConfigHash(without) == ConfigHash(with) {
+			t.Error("any non-zero config field should affect hash without explicit code changes")
 		}
 	})
 }

--- a/internal/container/container_test.go
+++ b/internal/container/container_test.go
@@ -974,6 +974,80 @@ func TestKitCredentialArgsFuncError(t *testing.T) {
 	}
 }
 
+func TestMavenCredentialsEndToEnd(t *testing.T) {
+	home := t.TempDir()
+	projectDir := t.TempDir()
+	t.Setenv("HOME", home)
+	cname := ContainerName(projectDir)
+
+	// Create fake ~/.m2/settings.xml with a "progress" server
+	m2Dir := filepath.Join(home, ".m2")
+	os.MkdirAll(m2Dir, 0755)
+	os.WriteFile(filepath.Join(m2Dir, "settings.xml"), []byte(`<?xml version="1.0"?>
+<settings>
+  <servers>
+    <server>
+      <id>progress</id>
+      <username>user</username>
+      <password>pass</password>
+    </server>
+  </servers>
+</settings>`), 0644)
+
+	// Write .asylum.local with explicit credentials (simulating the user's config)
+	os.WriteFile(filepath.Join(projectDir, ".asylum.local"), []byte(`kits:
+  java:
+    credentials:
+      - progress
+`), 0644)
+
+	cfg, err := config.Load(projectDir, config.CLIFlags{}, "")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.KitCredentialMode("java") != "explicit" {
+		t.Fatalf("KitCredentialMode = %q, want explicit", cfg.KitCredentialMode("java"))
+	}
+
+	// Use the real java/maven kit
+	allKits, err := kit.Resolve(cfg.KitNames(), cfg.DisabledKits())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	opts := RunOpts{
+		Config:     cfg,
+		Agent:      stubAgent{},
+		ProjectDir: projectDir,
+		Kits:       allKits,
+	}
+
+	args, err := kitCredentialArgs(home, cname, opts)
+	if err != nil {
+		t.Fatalf("kitCredentialArgs: %v", err)
+	}
+
+	credFound := false
+	for _, a := range args {
+		if a.Flag == "-v" && strings.Contains(a.Value, "settings.xml") {
+			credFound = true
+		}
+	}
+	if !credFound {
+		t.Fatalf("no settings.xml credential mount in args: %v", args)
+	}
+
+	// Verify only "progress" is in the generated file, not other servers
+	credFile := filepath.Join(home, ".asylum", "projects", cname, "credentials", "settings.xml")
+	data, err := os.ReadFile(credFile)
+	if err != nil {
+		t.Fatalf("credential file not written: %v", err)
+	}
+	if !strings.Contains(string(data), "<id>progress</id>") {
+		t.Errorf("expected progress server in credential file, got:\n%s", data)
+	}
+}
+
 func TestCoreVolumesNodeModulesShadowed(t *testing.T) {
 	home := t.TempDir()
 	projectDir := t.TempDir()

--- a/openspec/changes/archive/2026-04-08-docs-maven-credentials/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-08-docs-maven-credentials/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-08

--- a/openspec/changes/archive/2026-04-08-docs-maven-credentials/design.md
+++ b/openspec/changes/archive/2026-04-08-docs-maven-credentials/design.md
@@ -1,0 +1,12 @@
+## Context
+
+The `kit-credentials` change implemented Maven credential injection but did not include user-facing documentation. This change adds documentation only — no code changes.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Users can discover and configure Maven credentials from the docs
+
+**Non-Goals:**
+- No implementation changes
+- No new configuration options

--- a/openspec/changes/archive/2026-04-08-docs-maven-credentials/proposal.md
+++ b/openspec/changes/archive/2026-04-08-docs-maven-credentials/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+The Maven credential injection feature (`kit-credentials`) had no user-facing documentation. Users had no way to discover how to configure credentials, what the three modes are, or what the rebuild requirement is.
+
+## What Changes
+
+- `docs/kits/java.md` gets a `#### Maven Credentials` section under `java/maven` documenting auto mode, explicit mode, disabling, and the rebuild requirement
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+_(none — documentation only, no spec-level behavior changes)_
+
+## Impact
+
+- `docs/kits/java.md` only — no code changes

--- a/openspec/changes/archive/2026-04-08-docs-maven-credentials/specs/docs-site/spec.md
+++ b/openspec/changes/archive/2026-04-08-docs-maven-credentials/specs/docs-site/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Maven credentials documented
+The `docs/kits/java.md` page SHALL document the Maven credential injection feature under `java/maven`, covering auto mode, explicit mode, disabling, and the rebuild requirement.
+
+#### Scenario: User configures auto mode
+- **WHEN** a user reads `docs/kits/java.md`
+- **THEN** they SHALL find a `credentials: auto` example showing how to enable automatic pom.xml-based credential injection
+
+#### Scenario: User configures explicit mode
+- **WHEN** a user reads `docs/kits/java.md`
+- **THEN** they SHALL find an explicit mode example showing how to specify server IDs directly
+
+#### Scenario: User learns about rebuild requirement
+- **WHEN** a user reads `docs/kits/java.md`
+- **THEN** they SHALL find that credential changes require a container restart and that `--rebuild` applies them to a running container

--- a/openspec/changes/archive/2026-04-08-docs-maven-credentials/tasks.md
+++ b/openspec/changes/archive/2026-04-08-docs-maven-credentials/tasks.md
@@ -1,0 +1,3 @@
+## 1. Documentation
+
+- [x] 1.1 Add Maven Credentials section to `docs/kits/java.md`

--- a/openspec/changes/archive/2026-04-08-fix-credentials-config-hash/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-08-fix-credentials-config-hash/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-08

--- a/openspec/changes/archive/2026-04-08-fix-credentials-config-hash/design.md
+++ b/openspec/changes/archive/2026-04-08-fix-credentials-config-hash/design.md
@@ -1,0 +1,26 @@
+## Context
+
+The `ConfigHash` function serializes runtime-relevant config into a deterministic hash stored as a Docker label at container creation time. Asylum compares this label on the running container to detect config drift and warn the user to rebuild. The original implementation covered volumes, env vars, and ports but omitted kit credentials — a runtime-relevant value because credential mounts are injected at container start via bind mounts.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Kit credential settings (auto mode, or the sorted explicit ID list) are included in the config hash
+
+**Non-Goals:**
+- Changing what constitutes "runtime-relevant" config beyond credentials
+- Altering the hash format or label name
+
+## Decisions
+
+### Credentials serialized as `c:<kitName>=auto` or `c:<kitName>=<sorted-ids>`
+
+Iterate `cfg.Kits` in sorted key order. For each kit with non-nil `Credentials`: write `c:<kitName>=auto` for auto mode, or `c:<kitName>=<comma-joined-sorted-ids>` for explicit mode. Kits with nil credentials are skipped (off = no contribution to hash, same as absent).
+
+**Why sorted?** Determinism — explicit ID lists could be written in any order in the YAML.
+
+**Why skip nil?** Absent credentials don't affect container behavior, consistent with how absent volumes/env don't contribute.
+
+## Risks / Trade-offs
+
+**[Existing running containers get a false drift warning on first run after upgrade]** → Any container started before this fix has no credential contribution in its stored hash. After the fix, the computed hash will differ if the kit has credentials configured, triggering a warning. This is acceptable — the container genuinely needs to be restarted to pick up credential mounts.

--- a/openspec/changes/archive/2026-04-08-fix-credentials-config-hash/proposal.md
+++ b/openspec/changes/archive/2026-04-08-fix-credentials-config-hash/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+The config hash used for stale container detection did not include kit credential configuration. This meant that changing credentials in `.asylum` or `.asylum.local` would not trigger asylum's "config changed — restart with --rebuild" warning, leaving the container silently running with outdated credential mounts.
+
+## What Changes
+
+- `ConfigHash` now incorporates kit credential settings (auto mode or explicit server ID list) into its hash computation
+- Credential changes now produce a different hash, triggering the existing stale container warning
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `stale-container-detection`: The config hash now covers credentials in addition to volumes, env vars, and ports.
+
+## Impact
+
+- `internal/config/config.go` — `ConfigHash` function extended to iterate kit credentials
+- No config format changes, no new fields

--- a/openspec/changes/archive/2026-04-08-fix-credentials-config-hash/specs/stale-container-detection/spec.md
+++ b/openspec/changes/archive/2026-04-08-fix-credentials-config-hash/specs/stale-container-detection/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Config hash stored on container
+The config hash SHALL be stored as a Docker label (`asylum.config.hash`) on the container at creation time. The hash SHALL be computed from a deterministic serialization of runtime-relevant config values: sorted volumes, sorted env key-value pairs, sorted ports, and kit credential settings (sorted by kit name, with explicit ID lists also sorted).
+
+#### Scenario: New container creation
+- **WHEN** a new container is started via `docker run`
+- **THEN** the container SHALL have an `asylum.config.hash` label with the current config hash
+
+#### Scenario: Deterministic hash
+- **WHEN** the same config values are provided in different map iteration orders
+- **THEN** the computed hash SHALL be identical
+
+#### Scenario: Credential change detected
+- **WHEN** a kit's credential config changes (e.g. from `auto` to an explicit list, or explicit IDs are added)
+- **THEN** the config hash SHALL differ from the previously stored label, triggering the stale config warning
+
+#### Scenario: Absent credentials do not contribute
+- **WHEN** a kit has no credentials configured (`credentials` is absent or `false`)
+- **THEN** that kit SHALL contribute nothing to the config hash

--- a/openspec/changes/archive/2026-04-08-fix-credentials-config-hash/tasks.md
+++ b/openspec/changes/archive/2026-04-08-fix-credentials-config-hash/tasks.md
@@ -1,0 +1,7 @@
+## 1. Fix
+
+- [x] 1.1 Extend `ConfigHash` in `internal/config/config.go` to include kit credential settings
+
+## 2. Changelog
+
+- [x] 2.1 Add entry to CHANGELOG.md under Unreleased > Fixed

--- a/openspec/changes/archive/2026-04-08-fix-kit-credentials-merge/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-08-fix-kit-credentials-merge/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-08

--- a/openspec/changes/archive/2026-04-08-fix-kit-credentials-merge/design.md
+++ b/openspec/changes/archive/2026-04-08-fix-kit-credentials-merge/design.md
@@ -1,0 +1,26 @@
+## Context
+
+`mergeKitConfig` was introduced by the `deep-merge-kit-config` change. Its design document lists the field-level merge semantics for every `KitConfig` field at the time of writing. The `Credentials` field was added by the separate `kit-credentials` change (same date) and was never included in `mergeKitConfig`. The omission meant that any credential configuration in an overlay layer (project `.asylum` or `.asylum.local`) was silently dropped during merge, and the lower-layer value was retained instead.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `Credentials` participates in `mergeKitConfig` with last-wins semantics, consistent with all other non-accumulating scalar fields
+
+**Non-Goals:**
+- No other fields, behaviors, or config formats are changed
+- No migration needed — the fix only affects users who were relying on overlay configs for credentials (which never worked)
+
+## Decisions
+
+### Credentials uses last-wins semantics
+
+`if overlay.Credentials != nil { result.Credentials = overlay.Credentials }` — identical pattern to `Disabled`, `DefaultVersion`, `ShadowNodeModules`, etc.
+
+**Why not accumulate?** Credentials represent a complete intent: "use exactly these server IDs" or "use auto". There is no meaningful way to concatenate two credential configurations. An overlay that sets credentials should replace, not augment.
+
+**Alternative considered:** Merging the explicit ID lists (append). Rejected — if a user sets `credentials: [nexus]` in `.asylum.local`, they want exactly that, not the union with whatever the base declared.
+
+## Risks / Trade-offs
+
+**[No behavioral change for existing users]** → Anyone who had credentials configured only in the global `~/.asylum/config.yaml` or in `.asylum` (not overridden by a deeper layer) is unaffected. The bug only manifested when an overlay tried to set credentials.

--- a/openspec/changes/archive/2026-04-08-fix-kit-credentials-merge/proposal.md
+++ b/openspec/changes/archive/2026-04-08-fix-kit-credentials-merge/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+`mergeKitConfig` was introduced by the `deep-merge-kit-config` change but never updated to handle the `Credentials` field added shortly after by `kit-credentials`. As a result, credential configuration in overlay config files (`.asylum.local`, project `.asylum`) was silently discarded during merge, making it impossible to set or override credentials per-project.
+
+## What Changes
+
+- `mergeKitConfig` now carries the `Credentials` field from the overlay when non-nil (last-wins, matching the semantics of all other scalar fields)
+- No config format changes, no new fields, no behavioral changes for users who don't rely on overlay configs for credentials
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `deep-merge-kit-config`: The field-level merge rules for `KitConfig` now include `Credentials` with last-wins semantics, closing the gap left when `kit-credentials` added the field after `mergeKitConfig` was written.
+
+## Impact
+
+- `internal/config/config.go` — one-line fix in `mergeKitConfig`
+- No API changes, no config format changes, no migration needed

--- a/openspec/changes/archive/2026-04-08-fix-kit-credentials-merge/specs/deep-merge-kit-config/spec.md
+++ b/openspec/changes/archive/2026-04-08-fix-kit-credentials-merge/specs/deep-merge-kit-config/spec.md
@@ -1,30 +1,4 @@
-## ADDED Requirements
-
-### Requirement: Per-key kit map merge
-When merging two config layers, the `Kits` map SHALL be merged per-key: overlay keys add to or override base keys, and base keys not present in the overlay SHALL be preserved.
-
-#### Scenario: Project config adds kit without losing global kits
-- **WHEN** global config has `kits: {node: {}, openspec: {}}` and project config has `kits: {shell: {build: ["curl ..."]}}}`
-- **THEN** the merged result has kits `node`, `openspec`, and `shell` all active
-
-#### Scenario: Project config overrides a global kit's options
-- **WHEN** global config has `kits: {java: {default-version: "17"}}` and project config has `kits: {java: {default-version: "21"}}`
-- **THEN** the merged result has `java` with `default-version: "21"`
-
-#### Scenario: Overlay with nil KitConfig preserves base KitConfig
-- **WHEN** global config has `kits: {node: {packages: ["tsx"]}}` and project config has `kits: {node:}` (nil value)
-- **THEN** the merged result has `node` with `packages: ["tsx"]`
-
-#### Scenario: Base kit absent from overlay is preserved
-- **WHEN** global config has `kits: {openspec: {}}` and project config has `kits: {shell: {}}`
-- **THEN** the merged result contains both `openspec` and `shell`
-
-### Requirement: Per-key agent map merge
-When merging two config layers, the `Agents` map SHALL be merged per-key with the same semantics as kits.
-
-#### Scenario: Project adds agent without losing global agents
-- **WHEN** global config has `agents: {claude: {}}` and project config has `agents: {gemini: {}}`
-- **THEN** the merged result has both `claude` and `gemini` active
+## MODIFIED Requirements
 
 ### Requirement: KitConfig field-level merge
 When two KitConfig values exist for the same kit key, their fields SHALL be merged with field-appropriate semantics.

--- a/openspec/changes/archive/2026-04-08-fix-kit-credentials-merge/tasks.md
+++ b/openspec/changes/archive/2026-04-08-fix-kit-credentials-merge/tasks.md
@@ -1,0 +1,7 @@
+## 1. Fix
+
+- [x] 1.1 Add `Credentials` last-wins merge to `mergeKitConfig` in `internal/config/config.go`
+
+## 2. Changelog
+
+- [x] 2.1 Add entry to CHANGELOG.md under Unreleased > Fixed

--- a/openspec/changes/archive/2026-04-09-resilient-kit-config-merge-and-hash/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-09-resilient-kit-config-merge-and-hash/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-09

--- a/openspec/changes/archive/2026-04-09-resilient-kit-config-merge-and-hash/design.md
+++ b/openspec/changes/archive/2026-04-09-resilient-kit-config-merge-and-hash/design.md
@@ -1,0 +1,43 @@
+## Context
+
+`mergeKitConfig` and `ConfigHash` both manually enumerate `KitConfig` / `Config` fields. The `kit-credentials` change added a `Credentials` field to `KitConfig` but missed both functions — credentials were silently dropped during merge and excluded from the config hash. This is not a one-off oversight; it's a structural problem where any new field addition requires remembering to update two separate functions.
+
+## Goals / Non-Goals
+
+**Goals:**
+- New `KitConfig` fields participate in merge automatically with a sensible default (last-wins)
+- New `Config` fields participate in the config hash automatically
+- Accumulating fields (Packages, Build) remain explicitly declared, but at the struct level
+
+**Non-Goals:**
+- Changing merge or hash behavior for any existing field
+- Changing the `Config` or `KitConfig` struct shapes
+- Addressing the top-level `Merge()` function (it has far fewer fields and less churn)
+
+## Decisions
+
+### mergeKitConfig: reflection with struct tags
+
+Use `reflect` to iterate `KitConfig` fields. A `merge:"concat"` struct tag marks fields that accumulate (base + overlay). All other fields use last-wins (overlay replaces base when the overlay value is non-zero). The function becomes ~10 lines with no field enumeration.
+
+**Why struct tags?** The merge strategy is a property of the field, not the merge function. Declaring it at the struct level means a developer adding a new field sees the `merge` tags on neighboring fields and can decide whether theirs needs one. The default (no tag = last-wins) is correct for the majority of fields.
+
+**Why not a separate "strategy map"?** A map of field names to strategies is disconnected from the struct — the same "forgot to update" risk, just moved elsewhere.
+
+**Alternative considered:** Starting from `result := *overlay` and only filling zero-valued fields from base. This avoids reflection but still requires knowing which fields accumulate, and the zero-value check for `int` fields (like `Count`) means `0` can never be an intentional overlay value — same limitation as today, but less explicit.
+
+### ConfigHash: YAML serialization of the full config
+
+Replace the hand-rolled field-by-field hash with `yaml.Marshal(cfg)` after zeroing non-runtime fields (`Version`, `Agent`, `ReleaseChannel`, `Agents`). `yaml.v3` sorts map keys deterministically. `Volumes` and `Ports` are sorted before marshaling since their YAML order is not semantically meaningful.
+
+**Why zero non-runtime fields instead of listing runtime fields?** Listing runtime fields is the current approach and the source of the bug. Zeroing non-runtime fields inverts the default: new fields are included (safe — false positive warning) rather than excluded (unsafe — silent stale container).
+
+**Why not hash everything including non-runtime fields?** Changing `agent` or `release-channel` doesn't affect the running container. A false warning for those would be confusing.
+
+## Risks / Trade-offs
+
+**[One-time hash mismatch on upgrade]** → All running containers will get a config drift warning after this change because the hash computation changed entirely. Acceptable — the warning just says to restart, and it only happens once.
+
+**[Reflection has a runtime cost]** → Negligible. `mergeKitConfig` runs once at startup on a 12-field struct. The `reflect` overhead is unmeasurable against the Docker operations that follow.
+
+**[`Count: 0` cannot be set intentionally via overlay]** → Same limitation as before. `Count` uses `int` where zero is both "not set" and a valid value. This is a pre-existing issue unrelated to this change; fixing it would require changing `Count` to `*int`.

--- a/openspec/changes/archive/2026-04-09-resilient-kit-config-merge-and-hash/proposal.md
+++ b/openspec/changes/archive/2026-04-09-resilient-kit-config-merge-and-hash/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+`mergeKitConfig` and `ConfigHash` both manually enumerate `KitConfig` fields. When a new field is added, both must be updated — and forgetting either produces a silent bug (credentials merge and hash were both missed by the `kit-credentials` change). This is a structural problem: an open set of fields with a closed enumeration.
+
+## What Changes
+
+- `mergeKitConfig` uses reflection to iterate `KitConfig` fields, reading a `merge:"concat"` struct tag to determine strategy. Default (no tag) is last-wins. Adding a field no longer requires merge code changes.
+- `ConfigHash` serializes the full `Config` to YAML (deterministic map key ordering) after zeroing non-runtime fields, instead of manually serializing each field. New fields are included automatically.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `deep-merge-kit-config`: Merge strategy is now declared via struct tags rather than manual field enumeration. Behavior is unchanged for all existing fields.
+- `stale-container-detection`: Config hash now covers the full config (minus non-runtime fields) via YAML serialization instead of a hardcoded field list.
+
+## Impact
+
+- `internal/config/config.go` — `KitConfig` struct tags, `mergeKitConfig`, `ConfigHash`
+- `internal/config/config_test.go` — updated hash test expectations
+- New dependency on `reflect` (stdlib)

--- a/openspec/changes/archive/2026-04-09-resilient-kit-config-merge-and-hash/specs/deep-merge-kit-config/spec.md
+++ b/openspec/changes/archive/2026-04-09-resilient-kit-config-merge-and-hash/specs/deep-merge-kit-config/spec.md
@@ -1,30 +1,4 @@
-## ADDED Requirements
-
-### Requirement: Per-key kit map merge
-When merging two config layers, the `Kits` map SHALL be merged per-key: overlay keys add to or override base keys, and base keys not present in the overlay SHALL be preserved.
-
-#### Scenario: Project config adds kit without losing global kits
-- **WHEN** global config has `kits: {node: {}, openspec: {}}` and project config has `kits: {shell: {build: ["curl ..."]}}}`
-- **THEN** the merged result has kits `node`, `openspec`, and `shell` all active
-
-#### Scenario: Project config overrides a global kit's options
-- **WHEN** global config has `kits: {java: {default-version: "17"}}` and project config has `kits: {java: {default-version: "21"}}`
-- **THEN** the merged result has `java` with `default-version: "21"`
-
-#### Scenario: Overlay with nil KitConfig preserves base KitConfig
-- **WHEN** global config has `kits: {node: {packages: ["tsx"]}}` and project config has `kits: {node:}` (nil value)
-- **THEN** the merged result has `node` with `packages: ["tsx"]`
-
-#### Scenario: Base kit absent from overlay is preserved
-- **WHEN** global config has `kits: {openspec: {}}` and project config has `kits: {shell: {}}`
-- **THEN** the merged result contains both `openspec` and `shell`
-
-### Requirement: Per-key agent map merge
-When merging two config layers, the `Agents` map SHALL be merged per-key with the same semantics as kits.
-
-#### Scenario: Project adds agent without losing global agents
-- **WHEN** global config has `agents: {claude: {}}` and project config has `agents: {gemini: {}}`
-- **THEN** the merged result has both `claude` and `gemini` active
+## MODIFIED Requirements
 
 ### Requirement: KitConfig field-level merge
 When two KitConfig values exist for the same kit key, their fields SHALL be merged using struct-tag-driven reflection. Fields tagged `merge:"concat"` SHALL be accumulated (base + overlay). All other fields SHALL use last-wins semantics (overlay replaces base when the overlay value is non-zero). Adding a new field to `KitConfig` SHALL require no changes to the merge function.

--- a/openspec/changes/archive/2026-04-09-resilient-kit-config-merge-and-hash/specs/stale-container-detection/spec.md
+++ b/openspec/changes/archive/2026-04-09-resilient-kit-config-merge-and-hash/specs/stale-container-detection/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Config hash stored on container
+The config hash SHALL be stored as a Docker label (`asylum.config.hash`) on the container at creation time. The hash SHALL be computed by YAML-serializing the full `Config` struct (after zeroing non-runtime fields: `Version`, `Agent`, `ReleaseChannel`, `Agents`) and taking its SHA256 digest. Order-insensitive lists (`Volumes`, `Ports`) SHALL be sorted before serialization. New config fields SHALL be included in the hash automatically without code changes.
+
+#### Scenario: New container creation
+- **WHEN** a new container is started via `docker run`
+- **THEN** the container SHALL have an `asylum.config.hash` label with the current config hash
+
+#### Scenario: Deterministic hash
+- **WHEN** the same config values are provided in different map iteration orders
+- **THEN** the computed hash SHALL be identical
+
+#### Scenario: Credential change detected
+- **WHEN** a kit's credential config changes (e.g. from `auto` to an explicit list, or explicit IDs are added)
+- **THEN** the config hash SHALL differ from the previously stored label, triggering the stale config warning
+
+#### Scenario: New field automatically included
+- **WHEN** a new field is added to `Config` or `KitConfig`
+- **AND** that field is set to a non-zero value
+- **THEN** the config hash SHALL differ from a hash where that field is absent, without any changes to the hash function
+
+#### Scenario: Non-runtime fields excluded
+- **WHEN** only `Version`, `Agent`, `ReleaseChannel`, or `Agents` config changes
+- **THEN** the config hash SHALL NOT change
+
+#### Scenario: Volume/port order independent
+- **WHEN** the same volumes or ports are listed in a different order
+- **THEN** the computed hash SHALL be identical

--- a/openspec/changes/archive/2026-04-09-resilient-kit-config-merge-and-hash/tasks.md
+++ b/openspec/changes/archive/2026-04-09-resilient-kit-config-merge-and-hash/tasks.md
@@ -1,0 +1,12 @@
+## 1. Tag-driven mergeKitConfig
+
+- [x] 1.1 Add `merge:"concat"` struct tags to `Packages` and `Build` fields on `KitConfig`
+- [x] 1.2 Replace manual field enumeration in `mergeKitConfig` with reflection loop
+- [x] 1.3 Verify all existing `TestMergeKitConfig` cases still pass
+
+## 2. YAML-based ConfigHash
+
+- [x] 2.1 Replace hand-rolled `ConfigHash` serialization with `yaml.Marshal` after zeroing non-runtime fields
+- [x] 2.2 Sort `Volumes` and `Ports` before marshaling for order independence
+- [x] 2.3 Update "nil kit config" test expectation (declared kit differs from absent kit)
+- [x] 2.4 Verify all existing `TestConfigHash` cases still pass

--- a/openspec/specs/docs-site/spec.md
+++ b/openspec/specs/docs-site/spec.md
@@ -51,3 +51,18 @@ The `docs/getting-started.md` page SHALL walk through first run: what happens wh
 #### Scenario: First run explained
 - **WHEN** a user reads the getting started page
 - **THEN** they understand the base image build, agent config seeding, and how to start their first session
+
+### Requirement: Maven credentials documented
+The `docs/kits/java.md` page SHALL document the Maven credential injection feature under `java/maven`, covering auto mode, explicit mode, disabling, and the rebuild requirement.
+
+#### Scenario: User configures auto mode
+- **WHEN** a user reads `docs/kits/java.md`
+- **THEN** they SHALL find a `credentials: auto` example showing how to enable automatic pom.xml-based credential injection
+
+#### Scenario: User configures explicit mode
+- **WHEN** a user reads `docs/kits/java.md`
+- **THEN** they SHALL find an explicit mode example showing how to specify server IDs directly
+
+#### Scenario: User learns about rebuild requirement
+- **WHEN** a user reads `docs/kits/java.md`
+- **THEN** they SHALL find that credential changes require a container restart and that `--rebuild` applies them to a running container

--- a/openspec/specs/stale-container-detection/spec.md
+++ b/openspec/specs/stale-container-detection/spec.md
@@ -54,7 +54,7 @@ Asylum SHALL detect when non-image runtime config (volumes, env vars, ports) has
 - **THEN** asylum SHALL skip the config drift check (no warning)
 
 ### Requirement: Config hash stored on container
-The config hash SHALL be stored as a Docker label (`asylum.config.hash`) on the container at creation time. The hash SHALL be computed from a deterministic serialization of runtime-relevant config values: sorted volumes, sorted env key-value pairs, and sorted ports.
+The config hash SHALL be stored as a Docker label (`asylum.config.hash`) on the container at creation time. The hash SHALL be computed from a deterministic serialization of runtime-relevant config values: sorted volumes, sorted env key-value pairs, sorted ports, and kit credential settings (sorted by kit name, with explicit ID lists also sorted).
 
 #### Scenario: New container creation
 - **WHEN** a new container is started via `docker run`
@@ -63,6 +63,14 @@ The config hash SHALL be stored as a Docker label (`asylum.config.hash`) on the 
 #### Scenario: Deterministic hash
 - **WHEN** the same config values are provided in different map iteration orders
 - **THEN** the computed hash SHALL be identical
+
+#### Scenario: Credential change detected
+- **WHEN** a kit's credential config changes (e.g. from `auto` to an explicit list, or explicit IDs are added)
+- **THEN** the config hash SHALL differ from the previously stored label, triggering the stale config warning
+
+#### Scenario: Absent credentials do not contribute
+- **WHEN** a kit has no credentials configured (`credentials` is absent or `false`)
+- **THEN** that kit SHALL contribute nothing to the config hash
 
 ### Requirement: Unconditional image freshness check
 `EnsureBase` and `EnsureProject` SHALL be called on every `asylum` invocation, regardless of whether a container is currently running. When images are up to date, these calls SHALL return quickly (hash check only, no build).

--- a/openspec/specs/stale-container-detection/spec.md
+++ b/openspec/specs/stale-container-detection/spec.md
@@ -54,7 +54,7 @@ Asylum SHALL detect when non-image runtime config (volumes, env vars, ports) has
 - **THEN** asylum SHALL skip the config drift check (no warning)
 
 ### Requirement: Config hash stored on container
-The config hash SHALL be stored as a Docker label (`asylum.config.hash`) on the container at creation time. The hash SHALL be computed from a deterministic serialization of runtime-relevant config values: sorted volumes, sorted env key-value pairs, sorted ports, and kit credential settings (sorted by kit name, with explicit ID lists also sorted).
+The config hash SHALL be stored as a Docker label (`asylum.config.hash`) on the container at creation time. The hash SHALL be computed by YAML-serializing the full `Config` struct (after zeroing non-runtime fields: `Version`, `Agent`, `ReleaseChannel`, `Agents`) and taking its SHA256 digest. Order-insensitive lists (`Volumes`, `Ports`) SHALL be sorted before serialization. New config fields SHALL be included in the hash automatically without code changes.
 
 #### Scenario: New container creation
 - **WHEN** a new container is started via `docker run`
@@ -68,9 +68,18 @@ The config hash SHALL be stored as a Docker label (`asylum.config.hash`) on the 
 - **WHEN** a kit's credential config changes (e.g. from `auto` to an explicit list, or explicit IDs are added)
 - **THEN** the config hash SHALL differ from the previously stored label, triggering the stale config warning
 
-#### Scenario: Absent credentials do not contribute
-- **WHEN** a kit has no credentials configured (`credentials` is absent or `false`)
-- **THEN** that kit SHALL contribute nothing to the config hash
+#### Scenario: New field automatically included
+- **WHEN** a new field is added to `Config` or `KitConfig`
+- **AND** that field is set to a non-zero value
+- **THEN** the config hash SHALL differ from a hash where that field is absent, without any changes to the hash function
+
+#### Scenario: Non-runtime fields excluded
+- **WHEN** only `Version`, `Agent`, `ReleaseChannel`, or `Agents` config changes
+- **THEN** the config hash SHALL NOT change
+
+#### Scenario: Volume/port order independent
+- **WHEN** the same volumes or ports are listed in a different order
+- **THEN** the computed hash SHALL be identical
 
 ### Requirement: Unconditional image freshness check
 `EnsureBase` and `EnsureProject` SHALL be called on every `asylum` invocation, regardless of whether a container is currently running. When images are up to date, these calls SHALL return quickly (hash check only, no build).


### PR DESCRIPTION
Two bugs prevented Maven credentials configured in `.asylum` or `.asylum.local` from being injected into the container, plus a documentation gap that made the feature undiscoverable.                       
                                                                                                                                                                                                               
  ### Bugs fixed                                                                                                                                                                                               
                                                                  
  **Credentials silently dropped during config merge** — `mergeKitConfig` never handled the `Credentials` field. It was introduced by the `kit-credentials` change after `mergeKitConfig` was written, so the  
  field was silently dropped when merging config layers. Any credential config in a project `.asylum` or `.asylum.local` was ignored and the lower layer's value (or nothing) was used instead.
                                                                                                                                                                                                               
  **Credentials excluded from ConfigHash** — `ConfigHash` didn't include kit credentials, so credential changes didn't trigger the stale container warning. Users would change credentials and see no          
  indication that a rebuild was needed.
                                                                                                                                                                                                               
  ### Documentation                                               

  Added a Maven Credentials section to `docs/kits/java.md` covering auto mode (pom.xml-based discovery), explicit mode (direct server ID list), disabling, and the rebuild requirement.