### PR TITLE
Add Pi as a supported coding agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+- Pi coding agent support (`pi` agent option, installed via npm through fnm)
+
+### Fixed
+- `--agent <name>` now always includes that agent in the image build, even when not listed in the config file
+
 ## 0.6.6 — 2026-04-20
 
 Shared-mode hygiene and kit revivals. Kit-provided Claude skills (`agent-browser`, `ast-grep`) are no longer bind-mounted over the user's `~/.claude/skills/` — they're loaded from inside the container via Claude's `--add-dir` flag, so the host directory stays untouched. The `rtk` kit works again against current upstream rtk releases. Alongside: a new `~/.agents` host mount, `.yaml`-extension config files, a lowered default port range, and several credential and config-merge fixes.

--- a/cmd/asylum/main.go
+++ b/cmd/asylum/main.go
@@ -165,7 +165,17 @@ func main() {
 	globalKits, projectKits := resolveKitTiers(projectDir, allKits)
 
 	// Resolve agent installs (nil defaults to claude-only)
+	agentName := cfg.Agent
+	if agentName == "" {
+		agentName = "claude"
+	}
 	agentMap := agentConfigToMap(cfg.Agents)
+	// Ensure the active agent is in the install map so it gets baked into the image
+	if agentMap == nil {
+		agentMap = map[string]bool{agentName: true}
+	} else if !agentMap[agentName] {
+		agentMap[agentName] = true
+	}
 	kitNames := make([]string, len(allKits))
 	for i, k := range allKits {
 		kitNames[i] = k.Name
@@ -176,11 +186,6 @@ func main() {
 	}
 
 	cacheDirs := kit.AggregateCacheDirs(allKits)
-
-	agentName := cfg.Agent
-	if agentName == "" {
-		agentName = "claude"
-	}
 
 	a, err := agent.Get(agentName)
 	if err != nil {

--- a/docs/concepts/agents.md
+++ b/docs/concepts/agents.md
@@ -11,6 +11,7 @@ All agents run in YOLO mode (auto-approve all actions) by default.
 | [Claude Code](https://claude.ai) | `claude` | `--dangerously-skip-permissions` | `~/.claude` |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `gemini` | `--yolo` | `~/.gemini` |
 | [Codex](https://github.com/openai/codex) | `codex` | `--yolo` | `~/.codex` |
+| [Pi](https://github.com/mariozechner/pi-coding-agent) | `pi` | (none) | `~/.pi` |
 
 ## Selecting an Agent
 
@@ -18,6 +19,7 @@ All agents run in YOLO mode (auto-approve all actions) by default.
 asylum                # Claude Code (default)
 asylum -a gemini      # Gemini CLI
 asylum -a codex       # Codex
+asylum -a pi          # Pi
 ```
 
 Or set it in your config:
@@ -62,4 +64,4 @@ Or via CLI:
 asylum --agents claude,gemini
 ```
 
-Agent installation requires their kit dependencies (Gemini and Codex need the `node` kit).
+Agent installation requires their kit dependencies (Gemini, Codex, and Pi need the `node` kit).

--- a/internal/agent/install_test.go
+++ b/internal/agent/install_test.go
@@ -29,13 +29,13 @@ func TestResolveInstalls_EmptyMeansNone(t *testing.T) {
 }
 
 func TestResolveInstalls_ExplicitAll(t *testing.T) {
-	all := map[string]bool{"claude": true, "codex": true, "gemini": true, "opencode": true}
+	all := map[string]bool{"claude": true, "codex": true, "gemini": true, "opencode": true, "pi": true}
 	result, err := ResolveInstalls(all, []string{"node"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(result) != 4 {
-		t.Fatalf("expected 4 installs, got %d", len(result))
+	if len(result) != 5 {
+		t.Fatalf("expected 5 installs, got %d", len(result))
 	}
 }
 
@@ -60,10 +60,10 @@ func TestResolveInstalls_UnknownAgent(t *testing.T) {
 
 func TestAllInstallNames(t *testing.T) {
 	names := AllInstallNames()
-	if len(names) != 4 {
-		t.Fatalf("expected 4 agent installs, got %d: %v", len(names), names)
+	if len(names) != 5 {
+		t.Fatalf("expected 5 agent installs, got %d: %v", len(names), names)
 	}
-	expected := []string{"claude", "codex", "gemini", "opencode"}
+	expected := []string{"claude", "codex", "gemini", "opencode", "pi"}
 	for i, name := range expected {
 		if names[i] != name {
 			t.Errorf("names[%d] = %q, want %q", i, names[i], name)

--- a/internal/agent/pi.go
+++ b/internal/agent/pi.go
@@ -1,0 +1,49 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/inventage-ai/asylum/internal/term"
+)
+
+func init() {
+	agents["pi"] = Pi{}
+	RegisterInstall(&AgentInstall{
+		Name:           "pi",
+		DockerPriority: 6,
+		DockerSnippet: `# Install Pi
+RUN bash -c 'export PATH="$HOME/.local/share/fnm:$PATH" && eval "$(fnm env)" && npm install -g @mariozechner/pi-coding-agent'
+`,
+		KitDeps: []string{"node"},
+		BannerLine: `    echo "Pi:        $(pi --version 2>/dev/null || echo 'not found')"
+`,
+	})
+}
+
+type Pi struct{}
+
+func (Pi) Name() string               { return "pi" }
+func (Pi) Binary() string             { return "pi" }
+func (Pi) NativeConfigDir() string    { return "~/.pi" }
+func (Pi) ContainerConfigDir() string { return "~/.pi" }
+func (Pi) AsylumConfigDir() string    { return "~/.asylum/agents/pi" }
+
+func (Pi) EnvVars() map[string]string { return nil }
+
+func (Pi) HasSession(configDir, projectPath string) bool {
+	encoded := "--" + strings.ReplaceAll(projectPath, "/", "-") + "--"
+	sessDir := filepath.Join(configDir, "agent", "sessions", encoded)
+	_, err := os.Stat(sessDir)
+	return err == nil
+}
+
+func (Pi) Command(resume bool, extraArgs []string, _ CmdOpts) []string {
+	parts := []string{"pi"}
+	if resume {
+		parts = append(parts, "--continue")
+	}
+	parts = append(parts, term.ShellQuoteArgs(extraArgs)...)
+	return wrapZsh(strings.Join(parts, " "))
+}

--- a/openspec/changes/archive/2026-04-23-add-pi-agent/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-23-add-pi-agent/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-23

--- a/openspec/changes/archive/2026-04-23-add-pi-agent/design.md
+++ b/openspec/changes/archive/2026-04-23-add-pi-agent/design.md
@@ -1,0 +1,26 @@
+## Context
+
+Asylum supports multiple coding agents (claude, gemini, codex, opencode) through a uniform Agent interface in `internal/agent/`. Each agent is a struct implementing the interface, registered via `init()`, and paired with an `AgentInstall` for Dockerfile snippets and banner lines. Pi is the Asylum project's own coding agent and should be supported as a first-class option.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add pi as a selectable agent alongside existing agents
+- Follow the established pattern (struct + init registration + install snippet)
+- Support session detection and command generation for pi
+
+**Non-Goals:**
+- Modifying existing agent implementations
+- Changing the Agent interface
+- Adding new config options or CLI flags
+
+## Decisions
+
+- **Installation method**: pi is installed via npm (`@mariozechner/pi-coding-agent`) through fnm-managed node, following the same pattern as gemini and codex. Requires the `node` kit.
+- **Config directory**: `~/.pi` (native), `~/.asylum/agents/pi` (isolated) — consistent with the naming convention used by all other agents.
+- **Session detection**: pi stores session data in its config directory. We'll check for existing session files similar to how other agents do it.
+- **Command flags**: pi uses `--no-resume` / no flag for fresh/resume sessions. Exact flags determined by pi's CLI interface.
+
+## Risks / Trade-offs
+
+- pi's CLI flags may differ from other agents → mitigated by testing the command generation against pi's actual CLI

--- a/openspec/changes/archive/2026-04-23-add-pi-agent/proposal.md
+++ b/openspec/changes/archive/2026-04-23-add-pi-agent/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Pi is a coding agent that runs inside Asylum containers. Users should be able to select pi as their agent, just like claude, gemini, codex, and opencode. Currently pi is not recognized by the agent registry.
+
+## What Changes
+
+- Add `pi` as a new agent implementation in `internal/agent/`, following the existing pattern (claude.go, gemini.go, etc.)
+- Register pi in the agent install system with Dockerfile snippet for installation and a banner line
+- Update the agent-interface spec to include pi
+
+## Capabilities
+
+### New Capabilities
+
+- `pi-agent`: Pi agent implementation — registry entry, install snippet, command generation, session detection
+
+### Modified Capabilities
+
+- `agent-interface`: Add pi to the agent registry and command generation requirements
+
+## Impact
+
+- `internal/agent/pi.go` — new file
+- `openspec/specs/agent-interface/spec.md` — updated with pi scenarios
+- No breaking changes; purely additive

--- a/openspec/changes/archive/2026-04-23-add-pi-agent/specs/agent-interface/spec.md
+++ b/openspec/changes/archive/2026-04-23-add-pi-agent/specs/agent-interface/spec.md
@@ -1,0 +1,27 @@
+## MODIFIED Requirements
+
+### Requirement: Agent interface
+The agent package SHALL define an Agent interface with methods: Name, Binary, NativeConfigDir, ContainerConfigDir, AsylumConfigDir, EnvVars, HasSession, Command — matching PLAN.md section 8. The `Command` method SHALL accept an options parameter that carries context from the container layer (e.g. the shared kit-skills directory path), so agent implementations can tailor their launch command accordingly.
+
+#### Scenario: Interface methods
+- **WHEN** an Agent implementation is used
+- **THEN** all interface methods return correct values per the agent profile table in PLAN.md section 3.1
+
+#### Scenario: Command receives kit-skills context
+- **WHEN** `Command` is called with an options value whose `KitSkillsDir` field is `/opt/asylum-skills`
+- **THEN** agent implementations that care about skills (Claude) act on it, and agents that do not (Gemini, Codex, Opencode, Echo, Pi) ignore it
+
+### Requirement: Agent registry
+The agent package SHALL provide a Get function that returns an Agent by name ("claude", "gemini", "codex", "opencode", "pi") or an error for unknown names.
+
+#### Scenario: Valid agent lookup
+- **WHEN** `Get("gemini")` is called
+- **THEN** it returns the Gemini agent implementation with no error
+
+#### Scenario: Valid pi agent lookup
+- **WHEN** `Get("pi")` is called
+- **THEN** it returns the Pi agent implementation with no error
+
+#### Scenario: Invalid agent lookup
+- **WHEN** `Get("unknown")` is called
+- **THEN** it returns an error

--- a/openspec/changes/archive/2026-04-23-add-pi-agent/specs/pi-agent/spec.md
+++ b/openspec/changes/archive/2026-04-23-add-pi-agent/specs/pi-agent/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Pi agent registration
+The agent package SHALL register a `pi` agent in the global agents map, accessible via `agent.Get("pi")`.
+
+#### Scenario: Pi agent lookup
+- **WHEN** `Get("pi")` is called
+- **THEN** it returns the Pi agent implementation with no error
+
+### Requirement: Pi agent install definition
+The agent package SHALL register an `AgentInstall` for pi with a Dockerfile snippet that installs pi via npm (through fnm-managed node) and a banner line for the welcome screen. The install SHALL declare `node` as a kit dependency.
+
+#### Scenario: Pi install resolution
+- **WHEN** `ResolveInstalls` is called with `{"pi": true}` and `["node"]` in active kits
+- **THEN** it returns the pi AgentInstall with no error
+
+#### Scenario: Pi install without node kit
+- **WHEN** `ResolveInstalls` is called with `{"pi": true}` but `node` is not in active kits
+- **THEN** it emits a warning that pi requires the node kit
+
+### Requirement: Pi command generation
+Pi SHALL generate commands with the correct binary name and argument forwarding. Extra args are passed through; resume is handled via pi's session mechanism.
+
+#### Scenario: Default without resume
+- **WHEN** Command is called with resume=false and no extra args
+- **THEN** command runs `pi` with no resume flag
+
+#### Scenario: With resume
+- **WHEN** Command is called with resume=true and no extra args
+- **THEN** command runs `pi` with resume behavior
+
+#### Scenario: With extra args
+- **WHEN** Command is called with resume=false and extra args `["fix the bug"]`
+- **THEN** command runs `pi fix the bug`
+
+### Requirement: Pi session detection
+Pi SHALL detect existing sessions by checking for session files in its config directory.
+
+#### Scenario: Pi session exists
+- **WHEN** pi's config directory contains session data for the project
+- **THEN** HasSession returns true
+
+#### Scenario: No pi session
+- **WHEN** pi's config directory is empty or missing
+- **THEN** HasSession returns false

--- a/openspec/changes/archive/2026-04-23-add-pi-agent/tasks.md
+++ b/openspec/changes/archive/2026-04-23-add-pi-agent/tasks.md
@@ -1,0 +1,20 @@
+## 1. Create Pi agent implementation
+
+- [x] 1.1 Create `internal/agent/pi.go` with Pi struct implementing the Agent interface
+- [x] 1.2 Register Pi in `agents` map and `AgentInstall` in `init()` (npm install via fnm, node kit dependency, DockerPriority 6, banner line)
+- [x] 1.3 Implement `Name()`, `Binary()`, config dir methods (`~/.pi`, `~/.asylum/agents/pi`)
+- [x] 1.4 Implement `Command()` with `--continue` for resume, extra args passthrough, wrapped in zsh
+- [x] 1.5 Implement `HasSession()` checking `~/.pi/agent/sessions/` for project-matching directories (double-dash encoded path pattern)
+
+## 2. Fix active agent not auto-included in install map
+
+- [x] 2.1 Ensure `--agent <name>` always includes that agent in the install map (even when not in config)
+
+## 3. Update specs
+
+- [x] 3.1 Verify `specs/pi-agent/spec.md` covers all pi agent requirements
+- [x] 3.2 Verify `specs/agent-interface/spec.md` delta includes pi in registry and ignore list
+
+## 4. Update changelog
+
+- [x] 4.1 Add entry to `CHANGELOG.md` under Unreleased → Added


### PR DESCRIPTION
## Summary

Add Pi as a first-class coding agent alongside Claude Code, Gemini CLI, Codex, and OpenCode.

## Changes

- **`internal/agent/pi.go`** — New Pi agent implementation following the established pattern (struct + `init()` registration + `AgentInstall`). Installed via npm through fnm-managed node, requires the `node` kit.
- **`cmd/asylum/main.go`** — Fix: `--agent <name>` now always includes that agent in the image build, even when not listed in the config file.
- **`internal/agent/install_test.go`** — Update test expectations to account for the new agent.
- **`docs/concepts/agents.md`** — Document Pi in the agents table and usage examples.
- **`CHANGELOG.md`** — Add unreleased entries for both changes.

## Testing

All unit tests pass (`go test ./internal/agent/`).
